### PR TITLE
global.css 스냅 스크롤 타입 변경(#9)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,7 +11,8 @@ body {
   overflow-x: hidden;
 }
 
-section {
+/* Landing 페이지 전용 스냅 스크롤 */
+.landing-page section {
   scroll-snap-align: start;
   scroll-snap-stop: always;
 }

--- a/src/features/landing/presentation/pages/LandingPage.tsx
+++ b/src/features/landing/presentation/pages/LandingPage.tsx
@@ -18,7 +18,7 @@ import { Footer } from '../components/Footer';
  */
 export function LandingPage() {
     return (
-        <div className="bg-white text-slate-900 overflow-x-hidden">
+        <div className="landing-page bg-white text-slate-900 overflow-x-hidden">
             <Header />
             <SideNav />
 


### PR DESCRIPTION
# 🔀 PR 요약
- resolves #9 

## ✨ 변경 내용
- globals.css의 `section` 전역 스타일을 `.landing-page section`으로 스코프 제한
- 

## 🖼️ 스크린샷 (UI 변경 시 필수)
<img src="" width="50%" />

## 🔍 주요 포인트
- 다른 페이지 개발 시 <section> 태그에 스냅 스크롤이 적용되는 충돌 방지

## 🧪 테스트
- [x] 로컬에서 빌드 및 실행 확인
- [x] 주요 기능 동작 확인 (크롬 개발자 도구)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated scroll behavior to apply specifically to landing page sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->