### PR TITLE
feat: 로그인 API 실제 백엔드 연동 (#43)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,7 @@
-import axios from 'axios';
+import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
+
+const TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
 
 /**
  * API 클라이언트
@@ -12,51 +15,139 @@ export const apiClient = axios.create({
 });
 
 /**
- * - 모든 요청에 Authorization 헤더 자동 주입
+ * 토큰 저장/조회/삭제 헬퍼
+ */
+export const tokenStorage = {
+    getAccessToken: (): string | null => {
+        if (typeof window === 'undefined') return null;
+        return localStorage.getItem(TOKEN_KEY);
+    },
+    getRefreshToken: (): string | null => {
+        if (typeof window === 'undefined') return null;
+        return localStorage.getItem(REFRESH_TOKEN_KEY);
+    },
+    setTokens: (accessToken: string, refreshToken: string): void => {
+        localStorage.setItem(TOKEN_KEY, accessToken);
+        localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+    },
+    clearTokens: (): void => {
+        localStorage.removeItem(TOKEN_KEY);
+        localStorage.removeItem(REFRESH_TOKEN_KEY);
+    },
+};
+
+/**
+ * 모든 요청에 Authorization 헤더 자동 주입
  */
 apiClient.interceptors.request.use(
     (config) => {
-        // 클라이언트 사이드에서만 localStorage 접근
-        if (typeof window !== 'undefined') {
-            const token = localStorage.getItem('accessToken');
-            if (token) {
-                config.headers.Authorization = `Bearer ${token}`;
-            }
+        const token = tokenStorage.getAccessToken();
+        if (token) {
+            config.headers.Authorization = `Bearer ${token}`;
         }
         return config;
     },
-    (error) => {
-        return Promise.reject(error);
-    }
+    (error) => Promise.reject(error),
 );
 
 /**
- * AUTH_REQUIRED, AUTH_INVALID → 로그아웃
- * ACCESS_DENIED, ADMIN_SITE_FORBIDDEN, SITE_INACTIVE → 권한 에러
+ * 토큰 갱신 중복 방지
+ */
+let isRefreshing = false;
+let pendingRequests: Array<{
+    resolve: (token: string) => void;
+    reject: (error: unknown) => void;
+}> = [];
+
+function processPendingRequests(token: string | null, error: unknown = null): void {
+    pendingRequests.forEach(({ resolve, reject }) => {
+        if (token) {
+            resolve(token);
+        } else {
+            reject(error);
+        }
+    });
+    pendingRequests = [];
+}
+
+function redirectToLogin(): void {
+    tokenStorage.clearTokens();
+    if (typeof window !== 'undefined') {
+        window.location.href = '/login';
+    }
+}
+
+/**
+ * 401 → refresh 토큰으로 갱신 시도 → 실패 시 로그아웃
+ * 403 (ACCESS_DENIED, ADMIN_SITE_FORBIDDEN, SITE_INACTIVE) → 권한 에러 로그
  */
 apiClient.interceptors.response.use(
     (response) => response,
-    (error) => {
-        if (typeof window !== 'undefined') {
-            const errorCode = error.response?.data?.error?.code;
-            const status = error.response?.status;
+    async (error: AxiosError) => {
+        if (typeof window === 'undefined') return Promise.reject(error);
 
-            // 인증 관련 에러 → 로그아웃
-            if (errorCode === 'AUTH_REQUIRED' || errorCode === 'AUTH_INVALID' || status === 401) {
-                localStorage.removeItem('accessToken');
-                window.location.href = '/login';
+        const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+        const status = error.response?.status;
+        const errorCode = (error.response?.data as { error?: { code?: string } })?.error?.code;
+
+        // 401 + 아직 재시도 안 한 요청 → refresh 시도
+        if (status === 401 && !originalRequest._retry) {
+            // refresh 엔드포인트 자체가 401이면 바로 로그아웃
+            if (originalRequest.url?.includes('/admin/auth/refresh')) {
+                redirectToLogin();
+                return Promise.reject(error);
             }
 
-            // 권한 관련 에러
-            if (
-                errorCode === 'ACCESS_DENIED' ||
-                errorCode === 'ADMIN_SITE_FORBIDDEN' ||
-                errorCode === 'SITE_INACTIVE'
-            ) {
-                console.error('접근 권한이 없습니다:', errorCode);
+            originalRequest._retry = true;
+
+            if (isRefreshing) {
+                // 이미 갱신 진행 중 → 대기열에 추가
+                return new Promise<string>((resolve, reject) => {
+                    pendingRequests.push({ resolve, reject });
+                }).then((token) => {
+                    originalRequest.headers.Authorization = `Bearer ${token}`;
+                    return apiClient(originalRequest);
+                });
+            }
+
+            isRefreshing = true;
+            const refreshToken = tokenStorage.getRefreshToken();
+
+            if (!refreshToken) {
+                isRefreshing = false;
+                redirectToLogin();
+                return Promise.reject(error);
+            }
+
+            try {
+                const response = await apiClient.post('/admin/auth/refresh', {
+                    refresh_token: refreshToken,
+                });
+                const { access_token, refresh_token } = response.data.data;
+
+                tokenStorage.setTokens(access_token, refresh_token);
+                processPendingRequests(access_token);
+
+                originalRequest.headers.Authorization = `Bearer ${access_token}`;
+                return apiClient(originalRequest);
+            } catch (refreshError) {
+                processPendingRequests(null, refreshError);
+                redirectToLogin();
+                return Promise.reject(refreshError);
+            } finally {
+                isRefreshing = false;
             }
         }
 
+        // 권한 관련 에러
+        if (
+            errorCode === 'ACCESS_DENIED' ||
+            errorCode === 'ADMIN_SITE_FORBIDDEN' ||
+            errorCode === 'SITE_INACTIVE'
+        ) {
+            console.error('접근 권한이 없습니다:', errorCode);
+        }
+
         return Promise.reject(error);
-    }
+    },
 );

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,4 +1,6 @@
+'use client';
 
+import { AuthGuard } from '@/features/auth/presentation/components/AuthGuard';
 import { AdminSidebarContainer } from '@/features/admin/presentation/components/AdminSidebarContainer';
 import { AdminHeader } from '@/shared/components/layout/AdminHeader';
 
@@ -8,20 +10,22 @@ export default function AdminLayout({
     children: React.ReactNode;
 }) {
     return (
-        <div className="min-h-screen bg-slate-50">
-            {/* 사이드바 */}
-            <AdminSidebarContainer />
+        <AuthGuard>
+            <div className="min-h-screen bg-slate-50">
+                {/* 사이드바 */}
+                <AdminSidebarContainer />
 
-            {/* 메인 콘텐츠 영역 */}
-            <div className="lg:ml-64">
-                {/* 헤더 */}
-                <AdminHeader />
+                {/* 메인 콘텐츠 영역 */}
+                <div className="lg:ml-64">
+                    {/* 헤더 */}
+                    <AdminHeader />
 
-                {/* 페이지 콘텐츠 */}
-                <main className="p-6">
-                    {children}
-                </main>
+                    {/* 페이지 콘텐츠 */}
+                    <main className="p-6">
+                        {children}
+                    </main>
+                </div>
             </div>
-        </div>
+        </AuthGuard>
     );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,21 +1,42 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { LoginForm } from '@/features/auth/presentation/components/LoginForm';
 import { useAuth } from '@/features/auth/application/hooks/useAuth';
 
 export default function LoginPage() {
     const router = useRouter();
-    const { login, isLoading } = useAuth();
+    const { login, isLoading, isAuthenticated } = useAuth();
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    // 이미 로그인된 사용자는 대시보드로 리다이렉트
+    useEffect(() => {
+        if (!isLoading && isAuthenticated) {
+            router.replace('/admin');
+        }
+    }, [isLoading, isAuthenticated, router]);
 
     const handleLogin = async (email: string, password: string) => {
+        setErrorMessage(null);
         const success = await login(email, password);
         if (success) {
             router.push('/admin');
         } else {
-            alert('로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.');
+            setErrorMessage('이메일 또는 비밀번호가 올바르지 않습니다.');
         }
     };
 
-    return <LoginForm onSubmit={handleLogin} isLoading={isLoading} />;
+    // 이미 인증된 상태면 리다이렉트 대기
+    if (isAuthenticated) {
+        return null;
+    }
+
+    return (
+        <LoginForm
+            onSubmit={handleLogin}
+            isLoading={isLoading}
+            errorMessage={errorMessage}
+        />
+    );
 }

--- a/src/features/auth/application/store/AuthContext.tsx
+++ b/src/features/auth/application/store/AuthContext.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { createContext, useContext, useState, useCallback, ReactNode, useMemo } from 'react';
+import { createContext, useContext, useState, useCallback, useEffect, ReactNode, useMemo } from 'react';
 import type { AdminRole } from '@/shared/types/auth';
-import { INITIAL_MOCK_SITES } from '@/features/site/application/hooks/useSites';
+import { loginApi, getMeApi, logoutApi } from '@/api/endpoints/auth';
+import { tokenStorage } from '@/api/client';
 
 /**
- * Mock 사용자 정보
+ * 인증된 사용자 정보
  */
 export interface AuthUser {
     adminId: number;
@@ -15,7 +16,7 @@ export interface AuthUser {
 }
 
 /**
- * Mock 사이트 정보
+ * 사이트 정보
  */
 export interface Site {
     siteId: number;
@@ -39,7 +40,7 @@ interface AuthContextState {
  */
 interface AuthContextActions {
     login: (email: string, password: string) => Promise<boolean>;
-    logout: () => void;
+    logout: () => Promise<void>;
     setCurrentSite: (siteId: number) => void;
 }
 
@@ -47,72 +48,99 @@ type AuthContextType = AuthContextState & AuthContextActions;
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-/**
- * Mock 데이터
- */
-const MOCK_PLATFORM_ADMIN: AuthUser = {
-    adminId: 1,
-    email: 'admin@guideon.com',
-    role: 'PLATFORM_ADMIN',
-    siteIds: [],
-};
-
-const MOCK_SITE_ADMIN: AuthUser = {
-    adminId: 2,
-    email: 'operator@example.com',
-    role: 'SITE_ADMIN',
-    siteIds: [1],
-};
-
-
-
 interface AuthProviderProps {
     children: ReactNode;
 }
 
-export const DEFAULT_SITE_ID = 2; // 경복궁
-
 /**
  * AuthProvider
- * Mock 데이터 기반 인증 상태 관리
+ * 실제 백엔드 API 기반 인증 상태 관리
  */
 export function AuthProvider({ children }: AuthProviderProps) {
-    const [user, setUser] = useState<AuthUser | null>(MOCK_PLATFORM_ADMIN); // 기본: 로그인 상태
-    const [isLoading, setIsLoading] = useState(false);
-    const [currentSiteId, setCurrentSiteId] = useState<number | null>(DEFAULT_SITE_ID);
+    const [user, setUser] = useState<AuthUser | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [currentSiteId, setCurrentSiteId] = useState<number | null>(null);
+    const [sites] = useState<Site[]>([]);
 
     /**
-     * Mock 로그인
+     * 저장된 토큰으로 사용자 정보 복원 (새로고침 대응)
+     */
+    const restoreSession = useCallback(async () => {
+        const accessToken = tokenStorage.getAccessToken();
+        if (!accessToken) {
+            setIsLoading(false);
+            return;
+        }
+
+        try {
+            const response = await getMeApi();
+            const me = response.data;
+            setUser({
+                adminId: me.admin_id,
+                email: me.email,
+                role: me.role,
+                siteIds: me.site_ids,
+            });
+
+            if (me.role === 'SITE_ADMIN' && me.site_ids.length > 0) {
+                setCurrentSiteId(me.site_ids[0]);
+            }
+        } catch {
+            tokenStorage.clearTokens();
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        restoreSession();
+    }, [restoreSession]);
+
+    /**
+     * 로그인
      */
     const login = useCallback(async (email: string, password: string): Promise<boolean> => {
         setIsLoading(true);
 
-        // Mock: 간단한 지연
-        await new Promise((resolve) => setTimeout(resolve, 500));
+        try {
+            const response = await loginApi({ email, password });
+            const data = response.data;
 
-        if (email === 'admin@guideon.com' && password === 'admin1234') {
-            setUser(MOCK_PLATFORM_ADMIN);
-            setCurrentSiteId(DEFAULT_SITE_ID);
-            setIsLoading(false);
+            tokenStorage.setTokens(data.access_token, data.refresh_token);
+
+            setUser({
+                adminId: data.admin_id,
+                email: data.email,
+                role: data.role,
+                siteIds: data.site_ids ?? [],
+            });
+
+            if (data.role === 'SITE_ADMIN' && data.site_ids && data.site_ids.length > 0) {
+                setCurrentSiteId(data.site_ids[0]);
+            }
+
             return true;
-        } else if (email === 'operator@example.com' && password === 'operator1234') {
-            setUser(MOCK_SITE_ADMIN);
-            setCurrentSiteId(MOCK_SITE_ADMIN.siteIds.length > 0 ? MOCK_SITE_ADMIN.siteIds[0] : null);
+        } catch {
+            return false;
+        } finally {
             setIsLoading(false);
-            return true;
         }
-
-        setIsLoading(false);
-        return false;
     }, []);
 
     /**
      * 로그아웃
      */
-    const logout = useCallback(() => {
-        setUser(null);
-        setCurrentSiteId(null);
-        // 실제 구현 시: localStorage 정리, 리다이렉트
+    const logout = useCallback(async () => {
+        try {
+            await logoutApi();
+        } catch {
+            // 로그아웃 API 실패해도 로컬 정리는 진행
+        } finally {
+            tokenStorage.clearTokens();
+            setUser(null);
+            setCurrentSiteId(null);
+            window.location.href = '/login';
+        }
     }, []);
 
     /**
@@ -122,27 +150,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
         setCurrentSiteId(siteId);
     }, []);
 
-    /**
-     * 접근 가능한 사이트 목록
-     */
-    const availableSites = useMemo(() => {
-        if (!user) return [];
-        if (user.role === 'PLATFORM_ADMIN') return INITIAL_MOCK_SITES;
-        return INITIAL_MOCK_SITES.filter((site) => user.siteIds.includes(site.siteId));
-    }, [user]);
-
     const value = useMemo<AuthContextType>(
         () => ({
             user,
             isAuthenticated: !!user,
             isLoading,
             currentSiteId,
-            sites: availableSites,
+            sites,
             login,
             logout,
             setCurrentSite,
         }),
-        [user, isLoading, currentSiteId, availableSites, login, logout, setCurrentSite]
+        [user, isLoading, currentSiteId, sites, login, logout, setCurrentSite],
     );
 
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/features/auth/presentation/components/AuthGuard.tsx
+++ b/src/features/auth/presentation/components/AuthGuard.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/features/auth/application/hooks/useAuth';
+
+interface AuthGuardProps {
+    children: React.ReactNode;
+}
+
+/**
+ * AuthGuard
+ * 인증되지 않은 사용자를 로그인 페이지로 리다이렉트
+ * 세션 복원 중에는 로딩 UI를 표시
+ */
+export function AuthGuard({ children }: AuthGuardProps) {
+    const { isAuthenticated, isLoading } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (!isLoading && !isAuthenticated) {
+            router.replace('/login');
+        }
+    }, [isLoading, isAuthenticated, router]);
+
+    if (isLoading) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-slate-50">
+                <div className="flex flex-col items-center gap-3">
+                    <div className="w-8 h-8 border-3 border-orange-500 border-t-transparent rounded-full animate-spin" />
+                    <p className="text-sm text-slate-500 font-medium">로딩 중...</p>
+                </div>
+            </div>
+        );
+    }
+
+    if (!isAuthenticated) {
+        return null;
+    }
+
+    return <>{children}</>;
+}


### PR DESCRIPTION
# 🔀 PR 요약
- resolves #43

## ✨ 변경 내용
- mock 인증을 제거하고 배포된 백엔드에 로그인 api를 연동 했습니다.
- 

## 🖼️ 스크린샷 (UI 변경 시 필수)
<img src="" width="50%" />

## 🔍 주요 포인트
- 

## 🧪 테스트
- [x] 로컬에서 빌드 및 실행 확인
- [x] 주요 기능 동작 확인 (크롬 개발자 도구)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 백엔드 연동 인증 시스템 구현으로 보안 강화
  * 관리자 영역 접근 시 필수 인증 확인
  * 로그인 실패 시 오류 메시지 표시
  * 인증 중 로딩 상태 표시
  * 이미 로그인한 사용자는 자동으로 관리 페이지로 리다이렉트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->