### PR TITLE
[FEAT] Invite 목록 페이지 API 연동

### DIFF
--- a/src/api/endpoints/invite.ts
+++ b/src/api/endpoints/invite.ts
@@ -1,6 +1,22 @@
 import axios from 'axios';
+import { apiClient } from '../client';
 import type { ApiResponse } from '@/shared/types/api';
 import type { AcceptInviteRequest, AcceptInviteResponse } from '@/features/invite/domain/entities/Invite';
+
+/**
+ * Invite 응답 타입 (API snake_case)
+ */
+export interface InviteResponse {
+    invite_id: number;
+    site_id: number;
+    site_name: string;
+    email: string;
+    role: string;
+    status: 'PENDING' | 'ACCEPTED' | 'EXPIRED' | 'REVOKED';
+    expires_at: string;
+    created_at: string;
+    token?: string;
+}
 
 /**
  * 비인증 API 클라이언트
@@ -15,8 +31,55 @@ const publicClient = axios.create({
 /**
  * Invite API Endpoints
  *
- * POST /admin/invites/{inviteToken}/accept - 초대 수락 + 계정 생성 (공개, 인증 불필요)
+ * POST /admin/invites                        - 운영자 초대 생성 (PLATFORM_ADMIN)
+ * GET  /admin/invites                        - 초대 목록 조회 (PLATFORM_ADMIN)
+ * POST /admin/invites/{inviteId}/resend      - 초대 재발송 (PLATFORM_ADMIN)
+ * POST /admin/invites/{inviteId}/expire      - 초대 만료 처리 (PLATFORM_ADMIN)
+ * POST /admin/invites/{inviteToken}/accept   - 초대 수락 (비인증)
  */
+
+/**
+ * 운영자 초대 생성 (PLATFORM_ADMIN 전용)
+ */
+export const createInviteApi = async (data: { site_id: number; email: string }) => {
+    const response = await apiClient.post<ApiResponse<InviteResponse>>(
+        '/admin/invites',
+        data,
+    );
+    return response.data;
+};
+
+/**
+ * 초대 목록 조회 (PLATFORM_ADMIN 전용)
+ */
+export const getInvitesApi = async () => {
+    const response = await apiClient.get<ApiResponse<InviteResponse[]>>(
+        '/admin/invites',
+    );
+    return response.data;
+};
+
+/**
+ * 초대 재발송 (PLATFORM_ADMIN 전용)
+ * PENDING 상태의 초대에 대해 새 토큰을 발급하고 만료일을 리셋한 뒤 이메일을 재발송한다.
+ */
+export const resendInviteApi = async (inviteId: number) => {
+    const response = await apiClient.post<ApiResponse<InviteResponse>>(
+        `/admin/invites/${inviteId}/resend`,
+    );
+    return response.data;
+};
+
+/**
+ * 초대 만료 처리 (PLATFORM_ADMIN 전용)
+ * PENDING 상태의 초대를 만료 상태로 변경한다.
+ */
+export const expireInviteApi = async (inviteId: number) => {
+    const response = await apiClient.post<ApiResponse<null>>(
+        `/admin/invites/${inviteId}/expire`,
+    );
+    return response.data;
+};
 
 /**
  * 초대 수락 (비로그인)

--- a/src/api/endpoints/invite.ts
+++ b/src/api/endpoints/invite.ts
@@ -12,7 +12,7 @@ export interface InviteResponse {
     site_name: string;
     email: string;
     role: string;
-    status: 'PENDING' | 'ACCEPTED' | 'EXPIRED' | 'REVOKED';
+    status: 'PENDING' | 'USED' | 'EXPIRED';
     expires_at: string;
     created_at: string;
     token?: string;

--- a/src/api/endpoints/site.ts
+++ b/src/api/endpoints/site.ts
@@ -13,21 +13,6 @@ export interface SiteResponse {
 }
 
 /**
- * Invite 응답 타입
- */
-export interface InviteResponse {
-    invite_id: number;
-    site_id: number;
-    site_name: string;
-    email: string;
-    role: string;
-    status: 'PENDING' | 'ACCEPTED' | 'EXPIRED';
-    expires_at: string;
-    created_at: string;
-    token?: string;
-}
-
-/**
  * Site API Endpoints
  *
  * GET    /admin/sites                       - 관광지 목록 (PLATFORM_ADMIN)
@@ -36,9 +21,6 @@ export interface InviteResponse {
  * PATCH  /admin/sites/{siteId}              - 관광지 수정
  * POST   /admin/sites/{siteId}/activate     - 관광지 활성화
  * POST   /admin/sites/{siteId}/deactivate   - 관광지 비활성화
- *
- * POST   /admin/invites                     - 운영자 초대
- * GET    /admin/invites                     - 초대 목록 조회
  */
 
 /**
@@ -104,23 +86,3 @@ export const deactivateSiteApi = async (siteId: number) => {
     return response.data;
 };
 
-/**
- * 운영자 초대 생성 (PLATFORM_ADMIN 전용)
- */
-export const createInviteApi = async (data: { site_id: number; email: string }) => {
-    const response = await apiClient.post<ApiResponse<InviteResponse>>(
-        '/admin/invites',
-        data,
-    );
-    return response.data;
-};
-
-/**
- * 초대 목록 조회 (PLATFORM_ADMIN 전용)
- */
-export const getInvitesApi = async () => {
-    const response = await apiClient.get<ApiResponse<InviteResponse[]>>(
-        '/admin/invites',
-    );
-    return response.data;
-};

--- a/src/features/invite/application/hooks/useInvites.ts
+++ b/src/features/invite/application/hooks/useInvites.ts
@@ -26,8 +26,8 @@ function toInvite(response: InviteResponse): Invite {
 interface UseInvitesReturn {
     invites: Invite[];
     isLoading: boolean;
-    /** 현재 mutation 진행 중인 초대 ID (null이면 진행 중 없음) */
-    mutatingInviteId: number | null;
+    /** 현재 mutation 진행 중인 초대 ID 목록 */
+    mutatingInviteIds: Set<number>;
     error: ApiError | null;
     searchTerm: string;
     setSearchTerm: (term: string) => void;
@@ -44,14 +44,29 @@ interface UseInvitesReturn {
  *
  * - PLATFORM_ADMIN 전용
  * - 클라이언트 사이드 검색/필터링 (서버 페이지네이션 미지원)
+ * - 동시 mutation 지원 (Set 기반 per-invite 추적)
  */
 export function useInvites(): UseInvitesReturn {
     const [invites, setInvites] = useState<Invite[]>([]);
     const [isLoading, setIsLoading] = useState(false);
-    const [mutatingInviteId, setMutatingInviteId] = useState<number | null>(null);
+    const [mutatingInviteIds, setMutatingInviteIds] = useState<Set<number>>(new Set());
     const [error, setError] = useState<ApiError | null>(null);
     const [searchTerm, setSearchTerm] = useState('');
     const [statusFilter, setStatusFilter] = useState<InviteStatus | 'ALL'>('ALL');
+
+    /** mutation 시작: Set에 inviteId 추가 */
+    const addMutating = useCallback((inviteId: number) => {
+        setMutatingInviteIds((prev) => new Set(prev).add(inviteId));
+    }, []);
+
+    /** mutation 종료: Set에서 inviteId 제거 */
+    const removeMutating = useCallback((inviteId: number) => {
+        setMutatingInviteIds((prev) => {
+            const next = new Set(prev);
+            next.delete(inviteId);
+            return next;
+        });
+    }, []);
 
     /** 초대 목록 조회 */
     const fetchInvites = useCallback(async () => {
@@ -97,7 +112,7 @@ export function useInvites(): UseInvitesReturn {
 
     /** 초대 재발송 (PENDING 상태만 가능) */
     const resendInvite = useCallback(async (inviteId: number) => {
-        setMutatingInviteId(inviteId);
+        addMutating(inviteId);
         setError(null);
 
         try {
@@ -118,20 +133,29 @@ export function useInvites(): UseInvitesReturn {
         } catch (err) {
             setError(extractApiError(err));
         } finally {
-            setMutatingInviteId(null);
+            removeMutating(inviteId);
         }
-    }, []);
+    }, [addMutating, removeMutating]);
 
     /** 초대 만료 처리 (PENDING 상태만 가능) */
     const expireInvite = useCallback(async (inviteId: number) => {
-        setMutatingInviteId(inviteId);
+        addMutating(inviteId);
         setError(null);
 
         try {
             const response = await expireInviteApi(inviteId);
 
             if (response.success) {
-                await fetchInvites();
+                /** 즉시 로컬 상태 반영 (낙관적 업데이트) */
+                setInvites((prev) =>
+                    prev.map((invite) =>
+                        invite.inviteId === inviteId
+                            ? { ...invite, status: 'EXPIRED' as InviteStatus }
+                            : invite,
+                    ),
+                );
+                /** 서버와 전체 동기화 (실패해도 로컬 상태는 이미 반영) */
+                await fetchInvites().catch(() => { /* 로컬 상태로 유지 */ });
             } else {
                 setError({
                     code: response.error?.code ?? 'INTERNAL_ERROR',
@@ -141,14 +165,14 @@ export function useInvites(): UseInvitesReturn {
         } catch (err) {
             setError(extractApiError(err));
         } finally {
-            setMutatingInviteId(null);
+            removeMutating(inviteId);
         }
-    }, [fetchInvites]);
+    }, [addMutating, removeMutating, fetchInvites]);
 
     return {
         invites,
         isLoading,
-        mutatingInviteId,
+        mutatingInviteIds,
         error,
         searchTerm,
         setSearchTerm,

--- a/src/features/invite/application/hooks/useInvites.ts
+++ b/src/features/invite/application/hooks/useInvites.ts
@@ -110,16 +110,13 @@ export function useInvites(): UseInvitesReturn {
                     ),
                 );
             } else {
-                const apiError: ApiError = {
+                setError({
                     code: response.error?.code ?? 'INTERNAL_ERROR',
                     message: response.error?.message ?? '초대 재발송에 실패했습니다.',
-                };
-                setError(apiError);
-                throw new Error(apiError.message);
+                });
             }
         } catch (err) {
             setError(extractApiError(err));
-            throw err;
         } finally {
             setMutatingInviteId(null);
         }
@@ -136,16 +133,13 @@ export function useInvites(): UseInvitesReturn {
             if (response.success) {
                 await fetchInvites();
             } else {
-                const apiError: ApiError = {
+                setError({
                     code: response.error?.code ?? 'INTERNAL_ERROR',
                     message: response.error?.message ?? '초대 철회에 실패했습니다.',
-                };
-                setError(apiError);
-                throw new Error(apiError.message);
+                });
             }
         } catch (err) {
             setError(extractApiError(err));
-            throw err;
         } finally {
             setMutatingInviteId(null);
         }

--- a/src/features/invite/application/hooks/useInvites.ts
+++ b/src/features/invite/application/hooks/useInvites.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import type { Invite, InviteStatus } from '../../domain/entities/InviteEntry';
 import type { InviteResponse } from '@/api/endpoints/invite';
 import { getInvitesApi, resendInviteApi, expireInviteApi } from '@/api/endpoints/invite';
@@ -26,7 +26,8 @@ function toInvite(response: InviteResponse): Invite {
 interface UseInvitesReturn {
     invites: Invite[];
     isLoading: boolean;
-    isMutating: boolean;
+    /** 현재 mutation 진행 중인 초대 ID (null이면 진행 중 없음) */
+    mutatingInviteId: number | null;
     error: ApiError | null;
     searchTerm: string;
     setSearchTerm: (term: string) => void;
@@ -47,7 +48,7 @@ interface UseInvitesReturn {
 export function useInvites(): UseInvitesReturn {
     const [invites, setInvites] = useState<Invite[]>([]);
     const [isLoading, setIsLoading] = useState(false);
-    const [isMutating, setIsMutating] = useState(false);
+    const [mutatingInviteId, setMutatingInviteId] = useState<number | null>(null);
     const [error, setError] = useState<ApiError | null>(null);
     const [searchTerm, setSearchTerm] = useState('');
     const [statusFilter, setStatusFilter] = useState<InviteStatus | 'ALL'>('ALL');
@@ -79,22 +80,24 @@ export function useInvites(): UseInvitesReturn {
         fetchInvites();
     }, [fetchInvites]);
 
-    /** 클라이언트 사이드 검색/필터링 */
-    const filteredInvites = invites.filter((invite) => {
-        const matchesSearch =
-            searchTerm === '' ||
-            invite.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
-            invite.siteName.toLowerCase().includes(searchTerm.toLowerCase());
+    /** 클라이언트 사이드 검색/필터링 (메모이제이션) */
+    const filteredInvites = useMemo(() => {
+        return invites.filter((invite) => {
+            const matchesSearch =
+                searchTerm === '' ||
+                invite.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                invite.siteName.toLowerCase().includes(searchTerm.toLowerCase());
 
-        const matchesStatus =
-            statusFilter === 'ALL' || invite.status === statusFilter;
+            const matchesStatus =
+                statusFilter === 'ALL' || invite.status === statusFilter;
 
-        return matchesSearch && matchesStatus;
-    });
+            return matchesSearch && matchesStatus;
+        });
+    }, [invites, searchTerm, statusFilter]);
 
     /** 초대 재발송 (PENDING 상태만 가능) */
     const resendInvite = useCallback(async (inviteId: number) => {
-        setIsMutating(true);
+        setMutatingInviteId(inviteId);
         setError(null);
 
         try {
@@ -115,18 +118,16 @@ export function useInvites(): UseInvitesReturn {
                 throw new Error(apiError.message);
             }
         } catch (err) {
-            if (!error) {
-                setError(extractApiError(err));
-            }
+            setError(extractApiError(err));
             throw err;
         } finally {
-            setIsMutating(false);
+            setMutatingInviteId(null);
         }
-    }, [error]);
+    }, []);
 
     /** 초대 만료 처리 (PENDING 상태만 가능) */
     const expireInvite = useCallback(async (inviteId: number) => {
-        setIsMutating(true);
+        setMutatingInviteId(inviteId);
         setError(null);
 
         try {
@@ -143,19 +144,17 @@ export function useInvites(): UseInvitesReturn {
                 throw new Error(apiError.message);
             }
         } catch (err) {
-            if (!error) {
-                setError(extractApiError(err));
-            }
+            setError(extractApiError(err));
             throw err;
         } finally {
-            setIsMutating(false);
+            setMutatingInviteId(null);
         }
-    }, [error, fetchInvites]);
+    }, [fetchInvites]);
 
     return {
         invites,
         isLoading,
-        isMutating,
+        mutatingInviteId,
         error,
         searchTerm,
         setSearchTerm,

--- a/src/features/invite/application/hooks/useInvites.ts
+++ b/src/features/invite/application/hooks/useInvites.ts
@@ -1,63 +1,169 @@
-import { useState, useEffect } from 'react';
-import { Invite } from '../../domain/entities/InviteEntry';
+'use client';
 
-export function useInvites() {
+import { useState, useCallback, useEffect } from 'react';
+import type { Invite, InviteStatus } from '../../domain/entities/InviteEntry';
+import type { InviteResponse } from '@/api/endpoints/invite';
+import { getInvitesApi, resendInviteApi, expireInviteApi } from '@/api/endpoints/invite';
+import type { ApiError } from '@/shared/types/api';
+import { extractApiError } from '@/shared/utils/api';
+
+/**
+ * API 응답(snake_case) → 프론트엔드 엔티티(camelCase) 변환
+ */
+function toInvite(response: InviteResponse): Invite {
+    return {
+        inviteId: response.invite_id,
+        siteId: response.site_id,
+        siteName: response.site_name,
+        email: response.email,
+        role: response.role,
+        status: response.status,
+        expiresAt: response.expires_at,
+        createdAt: response.created_at,
+    };
+}
+
+interface UseInvitesReturn {
+    invites: Invite[];
+    isLoading: boolean;
+    isMutating: boolean;
+    error: ApiError | null;
+    searchTerm: string;
+    setSearchTerm: (term: string) => void;
+    statusFilter: InviteStatus | 'ALL';
+    setStatusFilter: (status: InviteStatus | 'ALL') => void;
+    filteredInvites: Invite[];
+    resendInvite: (inviteId: number) => Promise<void>;
+    expireInvite: (inviteId: number) => Promise<void>;
+    refetchInvites: () => Promise<void>;
+}
+
+/**
+ * useInvites - 초대 목록 조회/재발송/만료 처리 훅 (API 연동)
+ *
+ * - PLATFORM_ADMIN 전용
+ * - 클라이언트 사이드 검색/필터링 (서버 페이지네이션 미지원)
+ */
+export function useInvites(): UseInvitesReturn {
     const [invites, setInvites] = useState<Invite[]>([]);
     const [isLoading, setIsLoading] = useState(false);
+    const [isMutating, setIsMutating] = useState(false);
+    const [error, setError] = useState<ApiError | null>(null);
+    const [searchTerm, setSearchTerm] = useState('');
+    const [statusFilter, setStatusFilter] = useState<InviteStatus | 'ALL'>('ALL');
 
-    useEffect(() => {
-        const fetchInvites = async () => {
-            setIsLoading(true);
-            try {
-                const realisticMockData: Invite[] = [
-                    { id: 1, email: 'kim_manager@jeju.resort.com', siteName: '제주 만장굴', siteId: 101, status: 'ACCEPTED', createdAt: '2024-03-01', expiresAt: '2024-03-08' },
-                    { id: 2, email: 'lee_staff@palace.seoul.kr', siteName: '경복궁', siteId: 102, status: 'PENDING', createdAt: '2024-03-15', expiresAt: '2024-03-22' },
-                    { id: 3, email: 'park_op@bulguksa.or.kr', siteName: '불국사', siteId: 103, status: 'EXPIRED', createdAt: '2024-02-20', expiresAt: '2024-02-27' },
-                    { id: 4, email: 'admin_support@tour.gangwon.kr', siteName: '남이섬', siteId: 104, status: 'REVOKED', createdAt: '2024-03-05', expiresAt: '2024-03-12' },
-                    { id: 5, email: 'wrong_mail@invalid-domain.com', siteName: '제주 만장굴', siteId: 101, status: 'EXPIRED', createdAt: '2024-03-10', expiresAt: '2024-03-17', errorMsg: '발송 실패: 주소 형식 오류' },
-                    { id: 6, email: 'choi_master@namsantower.co.kr', siteName: 'N서울타워', siteId: 105, status: 'ACCEPTED', createdAt: '2024-03-02', expiresAt: '2024-03-09' },
-                    { id: 7, email: 'han_guide@lotteworld.com', siteName: '롯데월드', siteId: 106, status: 'PENDING', createdAt: '2024-03-18', expiresAt: '2024-03-25' },
-                    { id: 8, email: 'seo_manager@everland.co.kr', siteName: '에버랜드', siteId: 107, status: 'PENDING', createdAt: '2024-03-18', expiresAt: '2024-03-25' },
-                    { id: 9, email: 'it_support@busan.tower.kr', siteName: '부산타워', siteId: 108, status: 'EXPIRED', createdAt: '2024-02-15', expiresAt: '2024-02-22' },
-                    { id: 10, email: 'jung_admin@sokcho.sea.kr', siteName: '속초 해수욕장', siteId: 109, status: 'REVOKED', createdAt: '2024-03-12', expiresAt: '2024-03-19' },
-                    { id: 11, email: 'mail_error@server.com', siteName: '경복궁', siteId: 102, status: 'EXPIRED', createdAt: '2024-03-14', expiresAt: '2024-03-21', errorMsg: '발송 실패: SMTP 서버 거부' },
-                    { id: 12, email: 'kang_op@suwon.fortress.kr', siteName: '수원 화성', siteId: 110, status: 'ACCEPTED', createdAt: '2024-03-05', expiresAt: '2024-03-12' },
-                    { id: 13, email: 'yu_staff@hanok.village.kr', siteName: '전주 한옥마을', siteId: 111, status: 'PENDING', createdAt: '2024-03-17', expiresAt: '2024-03-24' },
-                    { id: 14, email: 'temp_user@naver.com', siteName: '불국사', siteId: 103, status: 'EXPIRED', createdAt: '2024-02-28', expiresAt: '2024-03-06' },
-                    { id: 15, email: 'master@ocean.world.kr', siteName: '오션월드', siteId: 112, status: 'ACCEPTED', createdAt: '2024-03-08', expiresAt: '2024-03-15' },
-                ];
-                setInvites(realisticMockData);
-            } finally {
-                setIsLoading(false);
+    /** 초대 목록 조회 */
+    const fetchInvites = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+
+        try {
+            const response = await getInvitesApi();
+
+            if (response.success) {
+                setInvites(response.data.map(toInvite));
+            } else {
+                setError({
+                    code: response.error?.code ?? 'INTERNAL_ERROR',
+                    message: response.error?.message ?? '초대 목록 조회에 실패했습니다.',
+                });
             }
-        };
-        fetchInvites();
+        } catch (err) {
+            setError(extractApiError(err));
+        } finally {
+            setIsLoading(false);
+        }
     }, []);
 
-    const cancelInvite = (id: number) => {
-        setInvites(prev => prev.map(inv => 
-            inv.id === id ? { ...inv, status: 'REVOKED' } : inv
-        ));
+    useEffect(() => {
+        fetchInvites();
+    }, [fetchInvites]);
+
+    /** 클라이언트 사이드 검색/필터링 */
+    const filteredInvites = invites.filter((invite) => {
+        const matchesSearch =
+            searchTerm === '' ||
+            invite.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
+            invite.siteName.toLowerCase().includes(searchTerm.toLowerCase());
+
+        const matchesStatus =
+            statusFilter === 'ALL' || invite.status === statusFilter;
+
+        return matchesSearch && matchesStatus;
+    });
+
+    /** 초대 재발송 (PENDING 상태만 가능) */
+    const resendInvite = useCallback(async (inviteId: number) => {
+        setIsMutating(true);
+        setError(null);
+
+        try {
+            const response = await resendInviteApi(inviteId);
+
+            if (response.success) {
+                setInvites((prev) =>
+                    prev.map((invite) =>
+                        invite.inviteId === inviteId ? toInvite(response.data) : invite,
+                    ),
+                );
+            } else {
+                const apiError: ApiError = {
+                    code: response.error?.code ?? 'INTERNAL_ERROR',
+                    message: response.error?.message ?? '초대 재발송에 실패했습니다.',
+                };
+                setError(apiError);
+                throw new Error(apiError.message);
+            }
+        } catch (err) {
+            if (!error) {
+                setError(extractApiError(err));
+            }
+            throw err;
+        } finally {
+            setIsMutating(false);
+        }
+    }, [error]);
+
+    /** 초대 만료 처리 (PENDING 상태만 가능) */
+    const expireInvite = useCallback(async (inviteId: number) => {
+        setIsMutating(true);
+        setError(null);
+
+        try {
+            const response = await expireInviteApi(inviteId);
+
+            if (response.success) {
+                await fetchInvites();
+            } else {
+                const apiError: ApiError = {
+                    code: response.error?.code ?? 'INTERNAL_ERROR',
+                    message: response.error?.message ?? '초대 철회에 실패했습니다.',
+                };
+                setError(apiError);
+                throw new Error(apiError.message);
+            }
+        } catch (err) {
+            if (!error) {
+                setError(extractApiError(err));
+            }
+            throw err;
+        } finally {
+            setIsMutating(false);
+        }
+    }, [error, fetchInvites]);
+
+    return {
+        invites,
+        isLoading,
+        isMutating,
+        error,
+        searchTerm,
+        setSearchTerm,
+        statusFilter,
+        setStatusFilter,
+        filteredInvites,
+        resendInvite,
+        expireInvite,
+        refetchInvites: fetchInvites,
     };
-
-    const resendInvite = (id: number) => {
-    const now = new Date();
-    const formattedToday = now.toISOString().split('T')[0];
-
-    const expiryDate = new Date();
-    expiryDate.setDate(now.getDate() + 7);
-    const formattedExpiry = expiryDate.toISOString().split('T')[0];
-
-    setInvites(prev => prev.map(inv => 
-        inv.id === id ? { 
-            ...inv, 
-            status: 'PENDING' as const,
-            createdAt: formattedToday,   
-            expiresAt: formattedExpiry,  // 현재 기준에서 7일 후로
-            errorMsg: undefined  
-        } : inv
-    ));
-    };
-
-    return { invites, isLoading, cancelInvite, resendInvite };
 }

--- a/src/features/invite/domain/entities/InviteEntry.ts
+++ b/src/features/invite/domain/entities/InviteEntry.ts
@@ -1,12 +1,12 @@
 export type InviteStatus = 'PENDING' | 'ACCEPTED' | 'EXPIRED' | 'REVOKED';
 
 export interface Invite {
-    id: number;
-    email: string;
-    siteName: string;
+    inviteId: number;
     siteId: number;
+    siteName: string;
+    email: string;
+    role: string;
     status: InviteStatus;
-    createdAt: string;
     expiresAt: string;
-    errorMsg?: string;
+    createdAt: string;
 }

--- a/src/features/invite/domain/entities/InviteEntry.ts
+++ b/src/features/invite/domain/entities/InviteEntry.ts
@@ -1,4 +1,4 @@
-export type InviteStatus = 'PENDING' | 'ACCEPTED' | 'EXPIRED' | 'REVOKED';
+export type InviteStatus = 'PENDING' | 'USED' | 'EXPIRED';
 
 export interface Invite {
     inviteId: number;

--- a/src/features/invite/presentation/components/InviteListView.tsx
+++ b/src/features/invite/presentation/components/InviteListView.tsx
@@ -4,13 +4,30 @@ import { useState } from 'react';
 import { HiOutlineEnvelope, HiOutlineMagnifyingGlass, HiOutlineExclamationTriangle, HiChevronDown } from 'react-icons/hi2';
 import { useInvites } from '../../application/hooks/useInvites';
 import { InviteTable } from './InviteTable';
+import type { InviteStatus } from '../../domain/entities/InviteEntry';
 
-export function InviteListView() { 
-    const { invites, cancelInvite, resendInvite } = useInvites();
-    const [searchTerm, setSearchTerm] = useState('');
-    const [statusFilter, setStatusFilter] = useState('ALL');
+const STATUS_OPTIONS: { value: InviteStatus | 'ALL'; label: string }[] = [
+    { value: 'ALL', label: '전체' },
+    { value: 'PENDING', label: '대기 중' },
+    { value: 'ACCEPTED', label: '수락됨' },
+    { value: 'EXPIRED', label: '만료됨' },
+    { value: 'REVOKED', label: '철회됨' },
+];
+
+export function InviteListView() {
+    const {
+        filteredInvites,
+        isLoading,
+        isMutating,
+        error,
+        searchTerm,
+        setSearchTerm,
+        statusFilter,
+        setStatusFilter,
+        resendInvite,
+        expireInvite,
+    } = useInvites();
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-    const [error, setError] = useState<string | null>(null);
 
     return (
         <div className="flex flex-col gap-4">
@@ -23,16 +40,13 @@ export function InviteListView() {
                 </div>
             </div>
 
-            {/* 에러 문구 영역 */}
             {error && (
                 <div className="bg-red-50 border border-red-100 p-4 rounded-2xl flex items-center gap-3">
                     <HiOutlineExclamationTriangle className="w-5 h-5 text-red-500" />
-                    <p className="text-sm font-bold text-red-600">{error}</p>
-                    <button onClick={() => setError(null)} className="ml-auto text-xs font-bold text-red-400">닫기</button>
+                    <p className="text-sm font-bold text-red-600">{error.message}</p>
                 </div>
             )}
 
-            {/* 필터 영역 */}
             <div className="bg-white p-4 rounded-2xl border border-slate-100 shadow-sm flex flex-wrap items-center gap-4">
                 <div className="flex items-center gap-3">
                     <span className="text-sm font-bold text-slate-500 whitespace-nowrap">검색</span>
@@ -53,22 +67,22 @@ export function InviteListView() {
                 <div className="flex items-center gap-3">
                     <span className="text-sm font-bold text-slate-500">상태</span>
                     <div className="relative">
-                        <button 
+                        <button
                             onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                             className="flex items-center gap-2 px-3 py-1.5 bg-white border border-slate-200 rounded-xl text-xs font-bold text-slate-700"
                         >
-                            {statusFilter === 'ALL' ? '전체' : statusFilter}
+                            {STATUS_OPTIONS.find((option) => option.value === statusFilter)?.label}
                             <HiChevronDown className={`w-3.5 h-3.5 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`} />
                         </button>
                         {isDropdownOpen && (
                             <div className="absolute top-full mt-2 w-32 bg-white border border-slate-100 rounded-xl shadow-xl z-50 p-1">
-                                {['ALL', 'PENDING', 'ACCEPTED', 'EXPIRED'].map((s) => (
-                                    <button 
-                                        key={s} 
-                                        onClick={() => { setStatusFilter(s); setIsDropdownOpen(false); }}
+                                {STATUS_OPTIONS.map((option) => (
+                                    <button
+                                        key={option.value}
+                                        onClick={() => { setStatusFilter(option.value); setIsDropdownOpen(false); }}
                                         className="w-full text-left px-3 py-2 rounded-lg text-xs font-bold hover:bg-orange-50 hover:text-orange-600"
                                     >
-                                        {s}
+                                        {option.label}
                                     </button>
                                 ))}
                             </div>
@@ -78,10 +92,12 @@ export function InviteListView() {
             </div>
 
             <div className="bg-white rounded-2xl border border-slate-100 shadow-sm">
-                <InviteTable 
-                    invites={invites} 
-                    onCancel={cancelInvite} 
-                    onResend={resendInvite} 
+                <InviteTable
+                    invites={filteredInvites}
+                    isLoading={isLoading}
+                    isMutating={isMutating}
+                    onExpire={expireInvite}
+                    onResend={resendInvite}
                 />
             </div>
         </div>

--- a/src/features/invite/presentation/components/InviteListView.tsx
+++ b/src/features/invite/presentation/components/InviteListView.tsx
@@ -9,9 +9,8 @@ import type { InviteStatus } from '../../domain/entities/InviteEntry';
 const STATUS_OPTIONS: { value: InviteStatus | 'ALL'; label: string }[] = [
     { value: 'ALL', label: '전체' },
     { value: 'PENDING', label: '대기 중' },
-    { value: 'ACCEPTED', label: '수락됨' },
+    { value: 'USED', label: '수락됨' },
     { value: 'EXPIRED', label: '만료됨' },
-    { value: 'REVOKED', label: '철회됨' },
 ];
 
 export function InviteListView() {

--- a/src/features/invite/presentation/components/InviteListView.tsx
+++ b/src/features/invite/presentation/components/InviteListView.tsx
@@ -17,7 +17,7 @@ export function InviteListView() {
     const {
         filteredInvites,
         isLoading,
-        mutatingInviteId,
+        mutatingInviteIds,
         error,
         searchTerm,
         setSearchTerm,
@@ -94,7 +94,7 @@ export function InviteListView() {
                 <InviteTable
                     invites={filteredInvites}
                     isLoading={isLoading}
-                    mutatingInviteId={mutatingInviteId}
+                    mutatingInviteIds={mutatingInviteIds}
                     onExpire={expireInvite}
                     onResend={resendInvite}
                 />

--- a/src/features/invite/presentation/components/InviteListView.tsx
+++ b/src/features/invite/presentation/components/InviteListView.tsx
@@ -17,7 +17,7 @@ export function InviteListView() {
     const {
         filteredInvites,
         isLoading,
-        isMutating,
+        mutatingInviteId,
         error,
         searchTerm,
         setSearchTerm,
@@ -94,7 +94,7 @@ export function InviteListView() {
                 <InviteTable
                     invites={filteredInvites}
                     isLoading={isLoading}
-                    isMutating={isMutating}
+                    mutatingInviteId={mutatingInviteId}
                     onExpire={expireInvite}
                     onResend={resendInvite}
                 />

--- a/src/features/invite/presentation/components/InviteTable.tsx
+++ b/src/features/invite/presentation/components/InviteTable.tsx
@@ -7,8 +7,8 @@ import type { Invite } from '@/features/invite/domain/entities/InviteEntry';
 interface InviteTableProps {
     invites: Invite[];
     isLoading: boolean;
-    /** 현재 mutation 진행 중인 초대 ID (null이면 진행 중 없음) */
-    mutatingInviteId: number | null;
+    /** 현재 mutation 진행 중인 초대 ID 목록 */
+    mutatingInviteIds: Set<number>;
     onExpire: (inviteId: number) => Promise<void>;
     onResend: (inviteId: number) => Promise<void>;
 }
@@ -23,10 +23,16 @@ const DEFAULT_STATUS = { label: '알 수 없음', className: 'bg-slate-50 text-s
 
 function formatDate(dateString: string): string {
     const date = new Date(dateString);
-    return date.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' });
+    return date.toLocaleString('ko-KR', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
 }
 
-export function InviteTable({ invites, isLoading, mutatingInviteId, onExpire, onResend }: InviteTableProps) {
+export function InviteTable({ invites, isLoading, mutatingInviteIds, onExpire, onResend }: InviteTableProps) {
     if (isLoading) {
         return (
             <div className="flex items-center justify-center py-16">
@@ -62,7 +68,7 @@ export function InviteTable({ invites, isLoading, mutatingInviteId, onExpire, on
                     <AnimatePresence mode="popLayout">
                         {invites.map((invite) => {
                             const statusInfo = STATUS_MAP[invite.status] ?? DEFAULT_STATUS;
-                            const isThisMutating = mutatingInviteId === invite.inviteId;
+                            const isThisMutating = mutatingInviteIds.has(invite.inviteId);
                             return (
                                 <motion.tr
                                     key={invite.inviteId}

--- a/src/features/invite/presentation/components/InviteTable.tsx
+++ b/src/features/invite/presentation/components/InviteTable.tsx
@@ -1,16 +1,51 @@
 'use client';
 
 import { motion, AnimatePresence } from 'framer-motion';
-import { HiOutlineArrowPath, HiOutlineXCircle, HiOutlineExclamationCircle } from 'react-icons/hi2';
-import { Invite } from '@/features/invite/domain/entities/InviteEntry';
+import { HiOutlineArrowPath, HiOutlineXCircle } from 'react-icons/hi2';
+import type { Invite } from '@/features/invite/domain/entities/InviteEntry';
 
 interface InviteTableProps {
     invites: Invite[];
-    onCancel: (id: number) => void;
-    onResend: (id: number) => void;
+    isLoading: boolean;
+    isMutating: boolean;
+    onExpire: (inviteId: number) => Promise<void>;
+    onResend: (inviteId: number) => Promise<void>;
 }
 
-export function InviteTable({ invites, onCancel, onResend }: InviteTableProps) {
+const STATUS_MAP: Record<string, { label: string; className: string }> = {
+    PENDING: { label: '대기 중', className: 'bg-amber-50 text-amber-600 border-amber-100' },
+    ACCEPTED: { label: '수락됨', className: 'bg-emerald-50 text-emerald-600 border-emerald-100' },
+    EXPIRED: { label: '만료됨', className: 'bg-slate-50 text-slate-400 border-slate-200' },
+    REVOKED: { label: '철회됨', className: 'bg-red-50 text-red-500 border-red-100' },
+};
+
+const DEFAULT_STATUS = { label: '알 수 없음', className: 'bg-slate-50 text-slate-400 border-slate-200' };
+
+function formatDateTime(dateString: string): string {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' });
+}
+
+export function InviteTable({ invites, isLoading, isMutating, onExpire, onResend }: InviteTableProps) {
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center py-16">
+                <div className="flex flex-col items-center gap-3">
+                    <div className="w-8 h-8 border-3 border-orange-200 border-t-orange-500 rounded-full animate-spin" />
+                    <span className="text-sm font-medium text-slate-400">초대 목록을 불러오는 중...</span>
+                </div>
+            </div>
+        );
+    }
+
+    if (invites.length === 0) {
+        return (
+            <div className="flex items-center justify-center py-16">
+                <span className="text-sm font-medium text-slate-400">초대 내역이 없습니다.</span>
+            </div>
+        );
+    }
+
     return (
         <div className="overflow-x-auto">
             <table className="w-full text-left">
@@ -19,68 +54,71 @@ export function InviteTable({ invites, onCancel, onResend }: InviteTableProps) {
                         <th className="px-6 py-4 text-[11px] font-bold text-slate-400 uppercase tracking-wider">대상 정보</th>
                         <th className="px-6 py-4 text-[11px] font-bold text-slate-400 uppercase tracking-wider text-center">상태</th>
                         <th className="px-6 py-4 text-[11px] font-bold text-slate-400 uppercase tracking-wider text-center">초대 일시</th>
+                        <th className="px-6 py-4 text-[11px] font-bold text-slate-400 uppercase tracking-wider text-center">만료 일시</th>
                         <th className="px-6 py-4 text-[11px] font-bold text-slate-400 uppercase tracking-wider text-right">작업</th>
                     </tr>
                 </thead>
                 <tbody>
                     <AnimatePresence mode="popLayout">
-                        {invites.map((invite) => (
-                            <motion.tr 
-                                key={invite.id} 
-                                layout
-                                initial={{ opacity: 0 }}
-                                animate={{ opacity: 1 }}
-                                exit={{ opacity: 0 }}
-                                className="border-b border-slate-50 last:border-0 hover:bg-slate-50/50 transition-colors group"
-                            >
-                                <td className="px-6 py-4">
-                                    <div className="flex flex-col">
-                                        <span className="text-sm font-bold text-slate-800">{invite.email}</span>
-                                        <span className="text-[11px] font-bold text-orange-500 uppercase">{invite.siteName}</span>
-                                    </div>
-                                </td>
-                                <td className="px-6 py-4">
-                                    <div className="flex flex-col items-center gap-1">
-                                        <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-bold 
-                                            ${invite.status === 'PENDING' ? 'bg-amber-50 text-amber-600 border-amber-100' : 
-                                              invite.status === 'ACCEPTED' ? 'bg-emerald-50 text-emerald-600 border-emerald-100' : 
-                                              invite.status === 'REVOKED' ? 'bg-red-50 text-red-500 border-red-100' :
-                                              'bg-slate-50 text-slate-400 border-slate-200'}`}>
-                                            {invite.status === 'PENDING' ? '대기 중' : 
-                                             invite.status === 'ACCEPTED' ? '수락됨' : 
-                                             invite.status === 'REVOKED' ? '취소됨' : '만료됨'}
-                                        </span>
-                                        {invite.errorMsg && (
-                                            <span className="text-[10px] text-red-500 flex items-center gap-1 font-medium">
-                                                <HiOutlineExclamationCircle className="w-3 h-3" /> 발송 실패
+                        {invites.map((invite) => {
+                            const statusInfo = STATUS_MAP[invite.status] ?? DEFAULT_STATUS;
+                            return (
+                                <motion.tr
+                                    key={invite.inviteId}
+                                    layout
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    className="border-b border-slate-50 last:border-0 hover:bg-slate-50/50 transition-colors group"
+                                >
+                                    <td className="px-6 py-4">
+                                        <div className="flex flex-col">
+                                            <span className="text-sm font-bold text-slate-800">{invite.email}</span>
+                                            <span className="text-[11px] font-bold text-orange-500 uppercase">{invite.siteName}</span>
+                                        </div>
+                                    </td>
+                                    <td className="px-6 py-4">
+                                        <div className="flex justify-center">
+                                            <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-bold ${statusInfo.className}`}>
+                                                {statusInfo.label}
                                             </span>
-                                        )}
-                                    </div>
-                                </td>
-                                <td className="px-6 py-4 text-center text-xs text-slate-500 font-medium">
-                                    {invite.createdAt}
-                                </td>
-                                <td className="px-6 py-4 text-right">
-                                    <div className="flex justify-end gap-1">
-                                        {invite.status === 'PENDING' && (
-                                            <button 
-                                                onClick={() => onCancel(invite.id)} 
-                                                className="p-2 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all" 
-                                                title="초대 취소"
-                                                aria-label={`${invite.email} 초대 취소`}
-                                                >
-                                                <HiOutlineXCircle className="w-5 h-5" />
-                                            </button>
-                                        )}
-                                        {(invite.status === 'EXPIRED' || invite.status === 'REVOKED') && (
-                                            <button onClick={() => onResend(invite.id)} className="p-2 text-slate-400 hover:text-orange-600 hover:bg-orange-50 rounded-lg transition-all" title="재전송" aria-label={`${invite.email} 초대 재전송`}>
-                                                <HiOutlineArrowPath className="w-5 h-5" />
-                                            </button>
-                                        )}
-                                    </div>
-                                </td>
-                            </motion.tr>
-                        ))}
+                                        </div>
+                                    </td>
+                                    <td className="px-6 py-4 text-center text-xs text-slate-500 font-medium">
+                                        {formatDateTime(invite.createdAt)}
+                                    </td>
+                                    <td className="px-6 py-4 text-center text-xs text-slate-500 font-medium">
+                                        {formatDateTime(invite.expiresAt)}
+                                    </td>
+                                    <td className="px-6 py-4 text-right">
+                                        <div className="flex justify-end gap-1">
+                                            {invite.status === 'PENDING' && (
+                                                <>
+                                                    <button
+                                                        onClick={() => onResend(invite.inviteId)}
+                                                        disabled={isMutating}
+                                                        className="p-2 text-slate-400 hover:text-orange-600 hover:bg-orange-50 rounded-lg transition-all disabled:opacity-50"
+                                                        title="재발송"
+                                                        aria-label={`${invite.email} 초대 재발송`}
+                                                    >
+                                                        <HiOutlineArrowPath className="w-5 h-5" />
+                                                    </button>
+                                                    <button
+                                                        onClick={() => onExpire(invite.inviteId)}
+                                                        disabled={isMutating}
+                                                        className="p-2 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50"
+                                                        title="초대 철회"
+                                                        aria-label={`${invite.email} 초대 철회`}
+                                                    >
+                                                        <HiOutlineXCircle className="w-5 h-5" />
+                                                    </button>
+                                                </>
+                                            )}
+                                        </div>
+                                    </td>
+                                </motion.tr>
+                            );
+                        })}
                     </AnimatePresence>
                 </tbody>
             </table>

--- a/src/features/invite/presentation/components/InviteTable.tsx
+++ b/src/features/invite/presentation/components/InviteTable.tsx
@@ -7,7 +7,8 @@ import type { Invite } from '@/features/invite/domain/entities/InviteEntry';
 interface InviteTableProps {
     invites: Invite[];
     isLoading: boolean;
-    isMutating: boolean;
+    /** 현재 mutation 진행 중인 초대 ID (null이면 진행 중 없음) */
+    mutatingInviteId: number | null;
     onExpire: (inviteId: number) => Promise<void>;
     onResend: (inviteId: number) => Promise<void>;
 }
@@ -25,7 +26,7 @@ function formatDateTime(dateString: string): string {
     return date.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' });
 }
 
-export function InviteTable({ invites, isLoading, isMutating, onExpire, onResend }: InviteTableProps) {
+export function InviteTable({ invites, isLoading, mutatingInviteId, onExpire, onResend }: InviteTableProps) {
     if (isLoading) {
         return (
             <div className="flex items-center justify-center py-16">
@@ -61,6 +62,7 @@ export function InviteTable({ invites, isLoading, isMutating, onExpire, onResend
                     <AnimatePresence mode="popLayout">
                         {invites.map((invite) => {
                             const statusInfo = STATUS_MAP[invite.status] ?? DEFAULT_STATUS;
+                            const isThisMutating = mutatingInviteId === invite.inviteId;
                             return (
                                 <motion.tr
                                     key={invite.inviteId}
@@ -95,16 +97,20 @@ export function InviteTable({ invites, isLoading, isMutating, onExpire, onResend
                                                 <>
                                                     <button
                                                         onClick={() => onResend(invite.inviteId)}
-                                                        disabled={isMutating}
+                                                        disabled={isThisMutating}
                                                         className="p-2 text-slate-400 hover:text-orange-600 hover:bg-orange-50 rounded-lg transition-all disabled:opacity-50"
                                                         title="재발송"
                                                         aria-label={`${invite.email} 초대 재발송`}
                                                     >
-                                                        <HiOutlineArrowPath className="w-5 h-5" />
+                                                        {isThisMutating ? (
+                                                            <div className="w-5 h-5 border-2 border-orange-200 border-t-orange-500 rounded-full animate-spin" />
+                                                        ) : (
+                                                            <HiOutlineArrowPath className="w-5 h-5" />
+                                                        )}
                                                     </button>
                                                     <button
                                                         onClick={() => onExpire(invite.inviteId)}
-                                                        disabled={isMutating}
+                                                        disabled={isThisMutating}
                                                         className="p-2 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50"
                                                         title="초대 철회"
                                                         aria-label={`${invite.email} 초대 철회`}

--- a/src/features/invite/presentation/components/InviteTable.tsx
+++ b/src/features/invite/presentation/components/InviteTable.tsx
@@ -21,7 +21,7 @@ const STATUS_MAP: Record<string, { label: string; className: string }> = {
 
 const DEFAULT_STATUS = { label: '알 수 없음', className: 'bg-slate-50 text-slate-400 border-slate-200' };
 
-function formatDateTime(dateString: string): string {
+function formatDate(dateString: string): string {
     const date = new Date(dateString);
     return date.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' });
 }
@@ -86,10 +86,10 @@ export function InviteTable({ invites, isLoading, mutatingInviteId, onExpire, on
                                         </div>
                                     </td>
                                     <td className="px-6 py-4 text-center text-xs text-slate-500 font-medium">
-                                        {formatDateTime(invite.createdAt)}
+                                        {formatDate(invite.createdAt)}
                                     </td>
                                     <td className="px-6 py-4 text-center text-xs text-slate-500 font-medium">
-                                        {formatDateTime(invite.expiresAt)}
+                                        {formatDate(invite.expiresAt)}
                                     </td>
                                     <td className="px-6 py-4 text-right">
                                         <div className="flex justify-end gap-1">
@@ -115,7 +115,11 @@ export function InviteTable({ invites, isLoading, mutatingInviteId, onExpire, on
                                                         title="초대 철회"
                                                         aria-label={`${invite.email} 초대 철회`}
                                                     >
-                                                        <HiOutlineXCircle className="w-5 h-5" />
+                                                        {isThisMutating ? (
+                                                            <div className="w-5 h-5 border-2 border-red-200 border-t-red-500 rounded-full animate-spin" />
+                                                        ) : (
+                                                            <HiOutlineXCircle className="w-5 h-5" />
+                                                        )}
                                                     </button>
                                                 </>
                                             )}

--- a/src/features/invite/presentation/components/InviteTable.tsx
+++ b/src/features/invite/presentation/components/InviteTable.tsx
@@ -14,9 +14,8 @@ interface InviteTableProps {
 
 const STATUS_MAP: Record<string, { label: string; className: string }> = {
     PENDING: { label: '대기 중', className: 'bg-amber-50 text-amber-600 border-amber-100' },
-    ACCEPTED: { label: '수락됨', className: 'bg-emerald-50 text-emerald-600 border-emerald-100' },
+    USED: { label: '수락됨', className: 'bg-emerald-50 text-emerald-600 border-emerald-100' },
     EXPIRED: { label: '만료됨', className: 'bg-slate-50 text-slate-400 border-slate-200' },
-    REVOKED: { label: '철회됨', className: 'bg-red-50 text-red-500 border-red-100' },
 };
 
 const DEFAULT_STATUS = { label: '알 수 없음', className: 'bg-slate-50 text-slate-400 border-slate-200' };

--- a/src/features/site/application/hooks/useSites.ts
+++ b/src/features/site/application/hooks/useSites.ts
@@ -8,10 +8,10 @@ import {
     updateSiteApi,
     activateSiteApi,
     deactivateSiteApi,
-    createInviteApi,
-    getInvitesApi,
 } from '@/api/endpoints/site';
-import type { SiteResponse, InviteResponse } from '@/api/endpoints/site';
+import { createInviteApi, getInvitesApi } from '@/api/endpoints/invite';
+import type { SiteResponse } from '@/api/endpoints/site';
+import type { InviteResponse } from '@/api/endpoints/invite';
 
 /**
  * 관광지 필터 상태

--- a/src/features/site/domain/entities/Site.ts
+++ b/src/features/site/domain/entities/Site.ts
@@ -25,7 +25,7 @@ export interface UpdateSiteRequest {
 }
 
 /** 초대 상태 */
-export type InviteStatus = 'PENDING' | 'ACCEPTED' | 'EXPIRED';
+export type InviteStatus = 'PENDING' | 'ACCEPTED' | 'EXPIRED' | 'REVOKED';
 
 /** 관광지에 배정된 운영자 초대 정보 */
 export interface SiteInvite {

--- a/src/features/site/domain/entities/Site.ts
+++ b/src/features/site/domain/entities/Site.ts
@@ -5,6 +5,8 @@
  * React에 의존하지 않는 순수 TypeScript 타입
  */
 
+import type { InviteStatus } from '@/features/invite/domain/entities/InviteEntry';
+
 /** 관광지 엔티티 */
 export interface Site {
     siteId: number;
@@ -23,9 +25,6 @@ export interface CreateSiteRequest {
 export interface UpdateSiteRequest {
     name: string;
 }
-
-/** 초대 상태 */
-export type InviteStatus = 'PENDING' | 'USED' | 'EXPIRED';
 
 /** 관광지에 배정된 운영자 초대 정보 */
 export interface SiteInvite {

--- a/src/features/site/domain/entities/Site.ts
+++ b/src/features/site/domain/entities/Site.ts
@@ -25,7 +25,7 @@ export interface UpdateSiteRequest {
 }
 
 /** 초대 상태 */
-export type InviteStatus = 'PENDING' | 'ACCEPTED' | 'EXPIRED' | 'REVOKED';
+export type InviteStatus = 'PENDING' | 'USED' | 'EXPIRED';
 
 /** 관광지에 배정된 운영자 초대 정보 */
 export interface SiteInvite {

--- a/src/features/site/presentation/components/SiteTable.tsx
+++ b/src/features/site/presentation/components/SiteTable.tsx
@@ -29,7 +29,7 @@ function formatDate(isoString: string): string {
  * 운영자 상태 뱃지 렌더링
  */
 function OperatorBadges({ invites }: { invites: SiteInvite[] }) {
-    const accepted = invites.filter((inv) => inv.status === 'ACCEPTED');
+    const accepted = invites.filter((inv) => inv.status === 'USED');
     const pending = invites.filter((inv) => inv.status === 'PENDING');
 
     if (accepted.length === 0 && pending.length === 0) {


### PR DESCRIPTION
# 🔀 PR 요약
- resolves #65 

## ✨ 변경 내용
- /admin/invites 페이지를 실제 백엔드 API로 연결했습니다.
- 

## 🖼️ 스크린샷 (UI 변경 시 필수)
<img src="" width="50%" />

## 🔍 주요 포인트
- mvp 마지막 연결 입니다.

## 🧪 테스트
- [x] 로컬에서 빌드 및 실행 확인
- [x] 주요 기능 동작 확인 (크롬 개발자 도구)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 초대 생성/조회/재전송/수락/만료 작업을 통한 서버 동기화 초대 흐름 제공
  * 초대 목록에서 검색·상태 필터 사용 가능

* **개선**
  * 초대 재전송·만료 버튼(대기중일 때만 표시)과 행 단위 뮤테이션 인디케이터 추가
  * 생성일(createdAt)·만료일(expiresAt) 표기 및 날짜 포맷 적용
  * 에러 메시지 노출·전역 상태 기반 필터링 및 “USED” 상태 반영으로 UI 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->