### PR TITLE
Feat: 디바이스 등록 API를 페어링 코드 방식으로 전환

### DIFF
--- a/src/api/endpoints/device.ts
+++ b/src/api/endpoints/device.ts
@@ -51,17 +51,19 @@ function toDevice(raw: RawDeviceResponse): Device {
 }
 
 /**
- * 페어링 등록 요청 시 snake_case 변환
+ * 페어링 등록 요청 바디 변환
+ *
+ * API_SPEC 8.6 기준 camelCase 사용
  */
 function toPairDeviceBody(request: CreateDeviceRequest) {
     return {
-        pairing_code: request.pairingCode,
-        device_id: request.deviceId,
-        location_name: request.locationName,
+        pairingCode: request.pairingCode,
+        deviceId: request.deviceId,
+        locationName: request.locationName,
         latitude: request.latitude,
         longitude: request.longitude,
-        zone_source: request.zoneSource,
-        zone_id: request.zoneId,
+        zoneSource: request.zoneSource,
+        zoneId: request.zoneId,
     };
 }
 

--- a/src/api/endpoints/device.ts
+++ b/src/api/endpoints/device.ts
@@ -102,7 +102,7 @@ export const pairDeviceApi = async (siteId: number, request: CreateDeviceRequest
     );
     return {
         ...response.data,
-        data: toDevice(response.data.data),
+        data: response.data.success ? toDevice(response.data.data) : null,
     };
 };
 

--- a/src/api/endpoints/device.ts
+++ b/src/api/endpoints/device.ts
@@ -1,6 +1,6 @@
 import { apiClient } from '../client';
 import type { ApiResponse, PaginatedResponse } from '@/shared/types/api';
-import type { Device, ZoneSource, CreateDeviceRequest, UpdateDeviceRequest, DeviceTokenResponse } from '@/features/device/domain/entities/Device';
+import type { Device, ZoneSource, CreateDeviceRequest, UpdateDeviceRequest, RotateTokenResponse } from '@/features/device/domain/entities/Device';
 
 /**
  * 백엔드 Device API 원본 응답 타입 (snake_case 혼재)
@@ -51,17 +51,17 @@ function toDevice(raw: RawDeviceResponse): Device {
 }
 
 /**
- * Device API 요청 시 snake_case 변환
+ * 페어링 등록 요청 시 snake_case 변환
  */
-function toDeviceCreateBody(request: CreateDeviceRequest) {
+function toPairDeviceBody(request: CreateDeviceRequest) {
     return {
+        pairing_code: request.pairingCode,
         device_id: request.deviceId,
         location_name: request.locationName,
         latitude: request.latitude,
         longitude: request.longitude,
         zone_source: request.zoneSource,
         zone_id: request.zoneId,
-        is_active: request.isActive,
     };
 }
 
@@ -79,7 +79,7 @@ function toDeviceUpdateBody(request: UpdateDeviceRequest) {
 /**
  * Device API Endpoints
  *
- * POST   /admin/sites/{siteId}/devices                              - 디바이스 등록
+ * POST   /admin/sites/{siteId}/devices/pair                         - 페어링 코드로 디바이스 등록
  * GET    /admin/sites/{siteId}/devices                              - 디바이스 목록
  * GET    /admin/sites/{siteId}/devices/{deviceId}                   - 디바이스 상세
  * PATCH  /admin/sites/{siteId}/devices/{deviceId}                   - 디바이스 수정
@@ -88,20 +88,19 @@ function toDeviceUpdateBody(request: UpdateDeviceRequest) {
  */
 
 /**
- * 디바이스 등록 (plainToken은 1회만 노출)
+ * 페어링 코드로 디바이스 등록
+ *
+ * 키오스크 화면의 6자리 코드로 디바이스를 매칭합니다.
+ * plainToken은 키오스크가 직접 수령하므로 응답에 포함되지 않습니다.
  */
-export const createDeviceApi = async (siteId: number, request: CreateDeviceRequest) => {
-    const response = await apiClient.post<ApiResponse<{ plainToken?: string; plain_token?: string; device: RawDeviceResponse }>>(
-        `/admin/sites/${siteId}/devices`,
-        toDeviceCreateBody(request),
+export const pairDeviceApi = async (siteId: number, request: CreateDeviceRequest) => {
+    const response = await apiClient.post<ApiResponse<RawDeviceResponse>>(
+        `/admin/sites/${siteId}/devices/pair`,
+        toPairDeviceBody(request),
     );
-    const raw = response.data.data;
     return {
         ...response.data,
-        data: {
-            plainToken: raw.plainToken ?? raw.plain_token ?? '',
-            device: toDevice(raw.device),
-        } as DeviceTokenResponse,
+        data: toDevice(response.data.data),
     };
 };
 
@@ -182,6 +181,7 @@ export const rotateDeviceTokenApi = async (siteId: number, deviceId: string) => 
         data: {
             plainToken: raw.plainToken ?? raw.plain_token ?? '',
             device: toDevice(raw.device),
-        } as DeviceTokenResponse,
+        } as RotateTokenResponse,
     };
 };
+

--- a/src/features/device/application/hooks/useDevices.ts
+++ b/src/features/device/application/hooks/useDevices.ts
@@ -93,7 +93,7 @@ export function useDevices(): UseDevicesReturn {
 
         try {
             const response = await pairDeviceApi(currentSiteId, request);
-            if (response.success) {
+            if (response.success && response.data) {
                 await fetchDevices();
                 return response.data;
             }

--- a/src/features/device/application/hooks/useDevices.ts
+++ b/src/features/device/application/hooks/useDevices.ts
@@ -1,9 +1,9 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
-import type { Device, CreateDeviceRequest, UpdateDeviceRequest, DeviceTokenResponse } from '@/features/device/domain/entities/Device';
+import type { Device, CreateDeviceRequest, UpdateDeviceRequest } from '@/features/device/domain/entities/Device';
 import { useSiteContext } from '@/features/auth/application/hooks/useAuth';
-import { getDevicesApi, createDeviceApi, updateDeviceApi, deleteDeviceApi, rotateDeviceTokenApi } from '@/api/endpoints/device';
+import { getDevicesApi, pairDeviceApi, updateDeviceApi, deleteDeviceApi, rotateDeviceTokenApi } from '@/api/endpoints/device';
 import type { ApiError } from '@/shared/types/api';
 import { extractApiError } from '@/shared/utils/api';
 
@@ -13,7 +13,7 @@ interface UseDevicesReturn {
     selectedDevice: Device | null;
     selectedDeviceId: string | null;
     setSelectedDeviceId: (id: string | null) => void;
-    createDevice: (request: CreateDeviceRequest) => Promise<DeviceTokenResponse>;
+    createDevice: (request: CreateDeviceRequest) => Promise<Device>;
     updateDevice: (deviceId: string, request: UpdateDeviceRequest) => Promise<Device>;
     deleteDevice: (deviceId: string) => Promise<void>;
     rotateToken: (deviceId: string) => Promise<string>;
@@ -27,8 +27,8 @@ interface UseDevicesReturn {
  * Device CRUD + 토큰 재발급 훅 (API 연동)
  *
  * - 현재 선택된 siteId 기준으로 Device 목록을 가져옵니다.
- * - 생성/수정/삭제/토큰재발급 후 자동으로 목록을 갱신합니다.
- * - plainToken은 등록/재발급 시 1회만 노출됩니다.
+ * - 페어링 등록/수정/삭제/토큰재발급 후 자동으로 목록을 갱신합니다.
+ * - 페어링 등록 시 plainToken은 키오스크가 직접 수령하므로 반환되지 않습니다.
  */
 export function useDevices(): UseDevicesReturn {
     const [devices, setDevices] = useState<Device[]>([]);
@@ -82,8 +82,8 @@ export function useDevices(): UseDevicesReturn {
         [devices, selectedDeviceId],
     );
 
-    /** 디바이스 등록 (plainToken 1회 노출) */
-    const createDevice = useCallback(async (request: CreateDeviceRequest): Promise<DeviceTokenResponse> => {
+    /** 페어링 코드로 디바이스 등록 (plainToken은 키오스크가 직접 수령) */
+    const createDevice = useCallback(async (request: CreateDeviceRequest): Promise<Device> => {
         if (currentSiteId === null) {
             throw new Error('현재 사이트가 선택되지 않았습니다.');
         }
@@ -92,7 +92,7 @@ export function useDevices(): UseDevicesReturn {
         setError(null);
 
         try {
-            const response = await createDeviceApi(currentSiteId, request);
+            const response = await pairDeviceApi(currentSiteId, request);
             if (response.success) {
                 await fetchDevices();
                 return response.data;

--- a/src/features/device/domain/entities/Device.ts
+++ b/src/features/device/domain/entities/Device.ts
@@ -30,16 +30,20 @@ export interface Device {
 }
 
 /**
- * 디바이스 등록 요청
+ * 페어링 코드 기반 디바이스 등록 요청
+ *
+ * 키오스크가 화면에 표시한 6자리 코드로 디바이스를 매칭합니다.
+ * - API_SPEC.md 섹션 8.6 기반
+ * - plainToken은 키오스크가 직접 수령하므로 응답에 포함되지 않음
  */
 export interface CreateDeviceRequest {
+    pairingCode: string;
     deviceId: string;
     locationName: string;
     latitude: number;
     longitude: number;
     zoneSource?: ZoneSource;
     zoneId?: number;
-    isActive?: boolean;
 }
 
 /**
@@ -57,11 +61,11 @@ export interface UpdateDeviceRequest {
 }
 
 /**
- * 디바이스 등록/토큰 재발급 응답
+ * 토큰 재발급 응답 (rotate-token 전용)
  *
  * plainToken은 1회만 노출 — 즉시 저장 필요
  */
-export interface DeviceTokenResponse {
+export interface RotateTokenResponse {
     plainToken: string;
     device: Device;
 }

--- a/src/features/device/presentation/components/DeviceFormModal.tsx
+++ b/src/features/device/presentation/components/DeviceFormModal.tsx
@@ -8,9 +8,7 @@ import {
     HiOutlineDevicePhoneMobile,
     HiOutlineMapPin,
     HiOutlineChevronDown,
-    HiOutlineClipboardDocument,
-    HiOutlineExclamationTriangle,
-    HiOutlineCheckCircle,
+    HiOutlineSignal,
 } from 'react-icons/hi2';
 import type { Device, CreateDeviceRequest, UpdateDeviceRequest } from '@/features/device/domain/entities/Device';
 import type { Zone } from '@/features/zone/domain/entities/Zone';
@@ -24,14 +22,16 @@ interface DeviceFormModalProps {
     selectedCoords: { lat: number; lng: number };
     onClose: () => void;
     onSubmit: (request: CreateDeviceRequest | UpdateDeviceRequest) => void | Promise<void>;
-    /** 등록 후 발급된 토큰 (create 성공 후 부모가 set) */
-    issuedToken: string | null;
 }
+
+/** 페어링 코드 유효성 정규식: 영문 대문자 + 숫자 6자리 */
+const PAIRING_CODE_REGEX = /^[A-Z0-9]{6}$/;
 
 /**
  * 디바이스 등록/수정 모달
  *
- * - 등록 성공 시 plainToken 1회 표시 + 복사 버튼 + 경고
+ * - 등록 시: 키오스크 화면의 6자리 페어링 코드를 입력하여 매칭
+ * - plainToken은 키오스크가 직접 수령하므로 토큰 표시 화면 없음
  * - PlaceFormModal과 동일한 UI 패턴
  */
 export function DeviceFormModal({
@@ -42,18 +42,29 @@ export function DeviceFormModal({
     selectedCoords,
     onClose,
     onSubmit,
-    issuedToken,
 }: DeviceFormModalProps) {
+    const [pairingCode, setPairingCode] = useState('');
     const [deviceId, setDeviceId] = useState(mode === 'edit' && editTarget ? editTarget.deviceId : '');
     const [locationName, setLocationName] = useState(mode === 'edit' && editTarget ? editTarget.locationName : '');
     const [zoneId, setZoneId] = useState<number | null>(mode === 'edit' && editTarget ? editTarget.zoneId : null);
     const [isActive, setIsActive] = useState(mode === 'edit' && editTarget ? editTarget.isActive : true);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-    const [isTokenCopied, setIsTokenCopied] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     const latitude = mode === 'edit' && editTarget ? editTarget.latitude : selectedCoords.lat;
     const longitude = mode === 'edit' && editTarget ? editTarget.longitude : selectedCoords.lng;
+
+    /** 페어링 코드 입력 핸들러 — 자동 대문자 변환 + 6자 제한 */
+    const handlePairingCodeChange = (value: string) => {
+        const sanitized = value.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
+        setPairingCode(sanitized);
+    };
+
+    const isPairingCodeValid = PAIRING_CODE_REGEX.test(pairingCode);
+
+    const isFormValid = mode === 'create'
+        ? isPairingCodeValid && deviceId.trim().length > 0 && locationName.trim().length > 0
+        : locationName.trim().length > 0;
 
     const handleSubmit = async (event: FormEvent) => {
         event.preventDefault();
@@ -61,13 +72,13 @@ export function DeviceFormModal({
         try {
             if (mode === 'create') {
                 const request: CreateDeviceRequest = {
+                    pairingCode,
                     deviceId: deviceId.trim(),
                     locationName: locationName.trim(),
                     latitude,
                     longitude,
                     zoneSource: zoneId != null ? 'MANUAL' : 'AUTO',
                     zoneId: zoneId ?? undefined,
-                    isActive,
                 };
                 await onSubmit(request);
             } else {
@@ -83,100 +94,6 @@ export function DeviceFormModal({
             setIsSubmitting(false);
         }
     };
-
-    const handleCopyToken = async () => {
-        if (!issuedToken) return;
-        try {
-            await navigator.clipboard.writeText(issuedToken);
-            setIsTokenCopied(true);
-            setTimeout(() => setIsTokenCopied(false), 2000);
-        } catch {
-            /* clipboard API 실패 시 무시 */
-        }
-    };
-
-    const isFormValid = deviceId.trim().length > 0 && locationName.trim().length > 0;
-
-    /** 토큰이 발급된 상태면 토큰 확인 화면 표시 */
-    if (issuedToken) {
-        return (
-            <AnimatePresence>
-                {isOpen && (
-                    <div className="fixed inset-0 z-50 overflow-y-auto">
-                        <div className="flex min-h-full items-center justify-center p-4">
-                            <motion.div
-                                initial={{ opacity: 0 }}
-                                animate={{ opacity: 1 }}
-                                exit={{ opacity: 0 }}
-                                className="fixed inset-0 bg-black/40"
-                            />
-                            <motion.div
-                                initial={{ opacity: 0, scale: 0.95, y: 20 }}
-                                animate={{ opacity: 1, scale: 1, y: 0 }}
-                                exit={{ opacity: 0, scale: 0.95, y: 20 }}
-                                transition={{ duration: 0.2 }}
-                                className="relative w-full max-w-md text-left bg-white rounded-2xl shadow-2xl"
-                            >
-                                <div className="px-6 py-4 border-b border-slate-100">
-                                    <h3 className="text-lg font-bold text-slate-800 flex items-center gap-2">
-                                        <HiOutlineCheckCircle className="w-5 h-5 text-green-500" />
-                                        디바이스 토큰 발급 완료
-                                    </h3>
-                                </div>
-
-                                <div className="p-6 space-y-4">
-                                    {/* 경고 배너 */}
-                                    <div className="bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 flex items-start gap-3">
-                                        <HiOutlineExclamationTriangle className="w-5 h-5 text-amber-500 shrink-0 mt-0.5" />
-                                        <div>
-                                            <p className="text-xs font-bold text-amber-700 mb-0.5">이 토큰은 지금만 확인할 수 있습니다</p>
-                                            <p className="text-[11px] text-amber-600">
-                                                창을 닫으면 다시 볼 수 없습니다. 반드시 복사하여 안전한 곳에 저장하세요.
-                                            </p>
-                                        </div>
-                                    </div>
-
-                                    {/* 토큰 표시 */}
-                                    <div className="bg-slate-50 border border-slate-200 rounded-xl px-4 py-3">
-                                        <p className="text-[10px] font-bold text-slate-400 mb-1.5 uppercase tracking-wider">Device Token</p>
-                                        <div className="flex items-center gap-2">
-                                            <code className="flex-1 text-sm font-mono text-slate-800 break-all select-all">
-                                                {issuedToken}
-                                            </code>
-                                            <button
-                                                type="button"
-                                                onClick={handleCopyToken}
-                                                className={`shrink-0 p-2 rounded-lg transition-all ${
-                                                    isTokenCopied
-                                                        ? 'bg-green-100 text-green-600'
-                                                        : 'bg-white border border-slate-200 text-slate-500 hover:bg-blue-50 hover:text-blue-600 hover:border-blue-200'
-                                                }`}
-                                                aria-label="토큰 복사"
-                                            >
-                                                {isTokenCopied ? (
-                                                    <HiOutlineCheckCircle className="w-4 h-4" />
-                                                ) : (
-                                                    <HiOutlineClipboardDocument className="w-4 h-4" />
-                                                )}
-                                            </button>
-                                        </div>
-                                    </div>
-
-                                    <button
-                                        type="button"
-                                        onClick={onClose}
-                                        className="w-full py-2.5 rounded-xl bg-orange-500 text-white text-sm font-bold hover:bg-orange-600 shadow-lg shadow-orange-200 transition-all active:scale-[0.98]"
-                                    >
-                                        확인
-                                    </button>
-                                </div>
-                            </motion.div>
-                        </div>
-                    </div>
-                )}
-            </AnimatePresence>
-        );
-    }
 
     return (
         <AnimatePresence>
@@ -201,7 +118,7 @@ export function DeviceFormModal({
                             <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100 shrink-0">
                                 <h3 className="text-lg font-bold text-slate-800 flex items-center gap-2">
                                     <HiOutlineDevicePhoneMobile className="w-5 h-5 text-violet-500" />
-                                    {mode === 'create' ? '디바이스 등록' : '디바이스 수정'}
+                                    {mode === 'create' ? '디바이스 페어링' : '디바이스 수정'}
                                 </h3>
                                 <button
                                     onClick={onClose}
@@ -228,6 +145,41 @@ export function DeviceFormModal({
                                     </div>
                                 )}
 
+                                {/* 페어링 코드 (등록 모드 전용) */}
+                                {mode === 'create' && (
+                                    <div>
+                                        <label htmlFor="pairing-code" className="block text-sm font-bold text-slate-700 mb-1.5">
+                                            페어링 코드 *
+                                        </label>
+                                        <div className="relative">
+                                            <div className="absolute left-3.5 top-1/2 -translate-y-1/2 text-teal-500">
+                                                <HiOutlineSignal className="w-4.5 h-4.5" />
+                                            </div>
+                                            <input
+                                                id="pairing-code"
+                                                type="text"
+                                                value={pairingCode}
+                                                onChange={(event) => handlePairingCodeChange(event.target.value)}
+                                                placeholder="예: A3F29K"
+                                                maxLength={6}
+                                                autoFocus
+                                                autoComplete="off"
+                                                spellCheck={false}
+                                                className={`w-full pl-10 pr-4 py-3 bg-white border rounded-xl text-base font-mono font-bold tracking-[0.3em] text-center text-slate-800 placeholder:text-slate-300 placeholder:tracking-[0.15em] placeholder:font-medium outline-none transition-all
+                                                    ${pairingCode.length > 0 && !isPairingCodeValid
+                                                        ? 'border-amber-300 focus:border-amber-400 focus:ring-4 focus:ring-amber-50'
+                                                        : isPairingCodeValid
+                                                            ? 'border-teal-300 focus:border-teal-400 focus:ring-4 focus:ring-teal-50'
+                                                            : 'border-slate-200 hover:border-teal-300 focus:border-teal-400 focus:ring-4 focus:ring-teal-50'
+                                                    }`}
+                                            />
+                                        </div>
+                                        <p className="text-[11px] font-medium text-slate-400 mt-1.5 leading-relaxed">
+                                            키오스크 화면에 표시된 6자리 코드를 입력하세요
+                                        </p>
+                                    </div>
+                                )}
+
                                 {/* 디바이스 ID */}
                                 <div>
                                     <label htmlFor="device-id" className="block text-sm font-bold text-slate-700 mb-1.5">디바이스 ID *</label>
@@ -239,7 +191,6 @@ export function DeviceFormModal({
                                         placeholder="예: KIOSK-MAIN-01"
                                         maxLength={50}
                                         disabled={mode === 'edit'}
-                                        autoFocus
                                         className={`w-full px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-sm font-medium text-slate-700 placeholder:text-slate-400 outline-none transition-all hover:border-violet-400 focus:border-violet-500 focus:ring-4 focus:ring-violet-50 ${
                                             mode === 'edit' ? 'bg-slate-50 text-slate-400 cursor-not-allowed' : ''
                                         }`}
@@ -326,20 +277,22 @@ export function DeviceFormModal({
                                     </div>
                                 </div>
 
-                                {/* 활성 상태 토글 */}
-                                <div className="flex items-center justify-between px-1">
-                                    <span className="text-sm font-bold text-slate-700">활성 상태</span>
-                                    <button
-                                        type="button"
-                                        onClick={() => setIsActive(!isActive)}
-                                        className={`relative w-11 h-6 rounded-full transition-colors duration-200 ${isActive ? 'bg-violet-500' : 'bg-slate-300'}`}
-                                        role="switch"
-                                        aria-checked={isActive}
-                                        aria-label="활성 상태 토글"
-                                    >
-                                        <span className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform duration-200 ${isActive ? 'translate-x-5' : ''}`} />
-                                    </button>
-                                </div>
+                                {/* 활성 상태 토글 (수정 모드 전용) */}
+                                {mode === 'edit' && (
+                                    <div className="flex items-center justify-between px-1">
+                                        <span className="text-sm font-bold text-slate-700">활성 상태</span>
+                                        <button
+                                            type="button"
+                                            onClick={() => setIsActive(!isActive)}
+                                            className={`relative w-11 h-6 rounded-full transition-colors duration-200 ${isActive ? 'bg-violet-500' : 'bg-slate-300'}`}
+                                            role="switch"
+                                            aria-checked={isActive}
+                                            aria-label="활성 상태 토글"
+                                        >
+                                            <span className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform duration-200 ${isActive ? 'translate-x-5' : ''}`} />
+                                        </button>
+                                    </div>
+                                )}
 
                                 {/* 액션 버튼 */}
                                 <div className="flex gap-3 pt-2">
@@ -358,7 +311,7 @@ export function DeviceFormModal({
                                         {isSubmitting && (
                                             <div className="w-4 h-4 rounded-full border-2 border-white/30 border-t-white animate-spin" />
                                         )}
-                                        {isSubmitting ? '저장 중...' : mode === 'create' ? '등록' : '저장'}
+                                        {isSubmitting ? '저장 중...' : mode === 'create' ? '페어링' : '저장'}
                                     </button>
                                 </div>
                             </form>

--- a/src/features/zone/presentation/components/ZonePlaceMapView.tsx
+++ b/src/features/zone/presentation/components/ZonePlaceMapView.tsx
@@ -371,11 +371,11 @@ export function ZonePlaceMapView() {
                 await updateDevice(deviceEditTarget.deviceId, request as UpdateDeviceRequest);
                 addToast('success', '디바이스가 수정되었습니다.');
             }
+            setPlacingPosition(null);
+            setIsDeviceFormOpen(false);
         } catch {
             addToast('error', deviceFormMode === 'create' ? '디바이스 페어링에 실패했습니다.' : '디바이스 수정에 실패했습니다.');
         }
-        setPlacingPosition(null);
-        setIsDeviceFormOpen(false);
     }, [deviceFormMode, deviceEditTarget, createDevice, updateDevice, addToast]);
 
     /** 구역 재계산 */

--- a/src/features/zone/presentation/components/ZonePlaceMapView.tsx
+++ b/src/features/zone/presentation/components/ZonePlaceMapView.tsx
@@ -163,7 +163,7 @@ export function ZonePlaceMapView() {
     const [deviceDeleteTarget, setDeviceDeleteTarget] = useState<Device | null>(null);
     const [isDeviceTokenOpen, setIsDeviceTokenOpen] = useState(false);
     const [deviceTokenTarget, setDeviceTokenTarget] = useState<Device | null>(null);
-    const [deviceIssuedToken, setDeviceIssuedToken] = useState<string | null>(null);
+    const [deviceRotatedToken, setDeviceRotatedToken] = useState<string | null>(null);
 
     const isGlobalLoading = isZonesLoading || isPlacesLoading || isDevicesLoading;
     const isMutating = isZoneMutating || isPlaceMutating || isDeviceMutating;
@@ -209,7 +209,6 @@ export function ZonePlaceMapView() {
             } else {
                 setDeviceFormMode('create');
                 setDeviceEditTarget(null);
-                setDeviceIssuedToken(null);
                 setIsDeviceFormOpen(true);
             }
             setInteractionMode('idle');
@@ -254,7 +253,6 @@ export function ZonePlaceMapView() {
         setDeviceFormMode('edit');
         setDeviceEditTarget(device);
         setSelectedCoords({ lat: device.latitude, lng: device.longitude });
-        setDeviceIssuedToken(null);
         setIsDeviceFormOpen(true);
     }, []);
 
@@ -265,7 +263,7 @@ export function ZonePlaceMapView() {
 
     const handleRotateToken = useCallback((device: Device) => {
         setDeviceTokenTarget(device);
-        setDeviceIssuedToken(null);
+        setDeviceRotatedToken(null);
         setIsDeviceTokenOpen(true);
     }, []);
 
@@ -310,7 +308,7 @@ export function ZonePlaceMapView() {
         if (!deviceTokenTarget) return;
         try {
             const newToken = await rotateToken(deviceTokenTarget.deviceId);
-            setDeviceIssuedToken(newToken);
+            setDeviceRotatedToken(newToken);
             addToast('success', '토큰이 재발급되었습니다. 새 토큰을 안전하게 저장하세요.');
         } catch {
             addToast('error', '토큰 재발급에 실패했습니다.');
@@ -367,18 +365,17 @@ export function ZonePlaceMapView() {
     const handleSubmitDeviceForm = useCallback(async (request: CreateDeviceRequest | UpdateDeviceRequest) => {
         try {
             if (deviceFormMode === 'create') {
-                const result = await createDevice(request as CreateDeviceRequest);
-                setDeviceIssuedToken(result.plainToken);
-                addToast('success', '디바이스가 등록되었습니다. 토큰을 안전하게 저장하세요.');
+                await createDevice(request as CreateDeviceRequest);
+                addToast('success', '디바이스가 페어링되었습니다.');
             } else if (deviceEditTarget) {
                 await updateDevice(deviceEditTarget.deviceId, request as UpdateDeviceRequest);
                 addToast('success', '디바이스가 수정되었습니다.');
-                setPlacingPosition(null);
-                setIsDeviceFormOpen(false);
             }
         } catch {
-            addToast('error', deviceFormMode === 'create' ? '디바이스 등록에 실패했습니다.' : '디바이스 수정에 실패했습니다.');
+            addToast('error', deviceFormMode === 'create' ? '디바이스 페어링에 실패했습니다.' : '디바이스 수정에 실패했습니다.');
         }
+        setPlacingPosition(null);
+        setIsDeviceFormOpen(false);
     }, [deviceFormMode, deviceEditTarget, createDevice, updateDevice, addToast]);
 
     /** 구역 재계산 */
@@ -815,8 +812,7 @@ export function ZonePlaceMapView() {
                 editTarget={deviceEditTarget}
                 zones={zones}
                 selectedCoords={selectedCoords}
-                issuedToken={deviceIssuedToken}
-                onClose={() => { setIsDeviceFormOpen(false); setPlacingPosition(null); setDeviceIssuedToken(null); }}
+                onClose={() => { setIsDeviceFormOpen(false); setPlacingPosition(null); }}
                 onSubmit={handleSubmitDeviceForm}
             />
             <DeviceDeleteDialog
@@ -829,8 +825,8 @@ export function ZonePlaceMapView() {
                 key={`device-token-${deviceTokenTarget?.deviceId}-${isDeviceTokenOpen}`}
                 isOpen={isDeviceTokenOpen}
                 deviceId={deviceTokenTarget?.deviceId ?? ''}
-                newToken={deviceIssuedToken}
-                onClose={() => { setIsDeviceTokenOpen(false); setDeviceIssuedToken(null); }}
+                newToken={deviceRotatedToken}
+                onClose={() => { setIsDeviceTokenOpen(false); setDeviceRotatedToken(null); }}
                 onConfirmRotate={handleConfirmRotateToken}
             />
         </div>


### PR DESCRIPTION
# 🔀 PR 요약
- resolves #69 

## ✨ 변경 내용
- 디바이스 등록 방식을 직접 등록(POST `/devices`)에서 **페어링 코드 방식**(POST `/devices/pair`)으로 전환 했습니다.

## 🖼️ 스크린샷 (UI 변경 시 필수)
<img src="" width="50%" />

## 🔍 주요 포인트
- 기존 수정/삭제/토큰 재발급 기능은 변경 없이 유지 했습니다.
- `deviceIssuedToken` 상태를 `deviceRotatedToken`으로 분리하여 재발급 전용으로 한정으로 했습니다.
- 등록 시 활성 상태 토글 제거 (페어링 방식에서는 항상 active)

## 🧪 테스트
- [x] 로컬에서 빌드 및 실행 확인
- [x] 주요 기능 동작 확인 (크롬 개발자 도구)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 페어링 코드 기반 기기 등록 프로세스 추가
* 페어링 코드 유효성 검사 및 입력 자동 포맷팅 기능

## 개선 사항

* UI 용어 변경: "기기 등록"에서 "기기 페어링"으로 업데이트
* 토큰 반환 방식 개선: 초기 페어링 시 토큰 미반환, 토큰 로테이션 시에만 반환
* 페어링 완료 시 사용자 알림 메시지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->