### PR TITLE
[FEAT] Admin RAG LLM 채팅 테스트 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ next-env.d.ts
 
 # docs
 /docs/
+CLAUDE.MD

--- a/src/api/endpoints/chat.ts
+++ b/src/api/endpoints/chat.ts
@@ -65,7 +65,7 @@ export const createChatSessionApi = async (
     body: CreateChatSessionRequest,
 ): Promise<ApiResponse<CreateChatSessionResponse>> => {
     const response = await apiClient.post<ApiResponse<CreateChatSessionResponse>>(
-        '/api/v1/admin/chat/sessions',
+        '/admin/chat/sessions',
         body,
     );
     return response.data;
@@ -77,7 +77,7 @@ export const sendChatMessageApi = async (
     body: SendChatMessageRequest,
 ): Promise<ApiResponse<SendChatMessageResponse>> => {
     const response = await apiClient.post<ApiResponse<RawSendChatMessageResponse>>(
-        `/api/v1/admin/chat/sessions/${sessionId}/messages`,
+        `/admin/chat/sessions/${sessionId}/messages`,
         body,
         { timeout: 90000 },
     );
@@ -93,7 +93,7 @@ export const endChatSessionApi = async (
     body: EndChatSessionRequest,
 ): Promise<ApiResponse<null>> => {
     const response = await apiClient.post<ApiResponse<null>>(
-        `/api/v1/admin/chat/sessions/${sessionId}/end`,
+        `/admin/chat/sessions/${sessionId}/end`,
         body,
     );
     return response.data;

--- a/src/api/endpoints/chat.ts
+++ b/src/api/endpoints/chat.ts
@@ -1,0 +1,100 @@
+import { apiClient } from '../client';
+import type { ApiResponse } from '@/shared/types/api';
+import type {
+    CreateChatSessionRequest,
+    CreateChatSessionResponse,
+    SendChatMessageRequest,
+    SendChatMessageResponse,
+    EndChatSessionRequest,
+} from '@/features/chat/domain/entities/Chat';
+
+/**
+ * 백엔드 채팅 메시지 응답 원본 타입 (snake_case/camelCase 혼재 대응)
+ */
+interface RawSendChatMessageResponse {
+    sessionId?: string;
+    session_id?: string;
+    answer: string;
+    emotion?: string | null;
+    language?: string | null;
+    category?: string | null;
+    deviceLatitude?: number | null;
+    device_latitude?: number | null;
+    deviceLongitude?: number | null;
+    device_longitude?: number | null;
+    placeId?: number | null;
+    place_id?: number | null;
+    placeName?: string | null;
+    place_name?: string | null;
+    imageUrl?: string | null;
+    image_url?: string | null;
+    latitude?: number | null;
+    longitude?: number | null;
+}
+
+/**
+ * 백엔드 응답을 프론트 엔티티로 정규화
+ */
+function toChatMessageResponse(raw: RawSendChatMessageResponse): SendChatMessageResponse {
+    return {
+        sessionId: raw.sessionId ?? raw.session_id ?? '',
+        answer: raw.answer,
+        emotion: raw.emotion ?? null,
+        language: raw.language ?? null,
+        category: raw.category ?? null,
+        deviceLatitude: raw.deviceLatitude ?? raw.device_latitude ?? null,
+        deviceLongitude: raw.deviceLongitude ?? raw.device_longitude ?? null,
+        placeId: raw.placeId ?? raw.place_id ?? null,
+        placeName: raw.placeName ?? raw.place_name ?? null,
+        imageUrl: raw.imageUrl ?? raw.image_url ?? null,
+        latitude: raw.latitude ?? null,
+        longitude: raw.longitude ?? null,
+    };
+}
+
+/**
+ * Chat API Endpoints
+ *
+ * POST /api/v1/admin/chat/sessions                        - 세션 생성
+ * POST /api/v1/admin/chat/sessions/{sessionId}/messages   - 메시지 전송
+ * POST /api/v1/admin/chat/sessions/{sessionId}/end        - 세션 종료
+ */
+
+/** 채팅 세션 생성 */
+export const createChatSessionApi = async (
+    body: CreateChatSessionRequest,
+): Promise<ApiResponse<CreateChatSessionResponse>> => {
+    const response = await apiClient.post<ApiResponse<CreateChatSessionResponse>>(
+        '/api/v1/admin/chat/sessions',
+        body,
+    );
+    return response.data;
+};
+
+/** 채팅 메시지 전송 (AI 응답까지 최대 60초 소요) */
+export const sendChatMessageApi = async (
+    sessionId: string,
+    body: SendChatMessageRequest,
+): Promise<ApiResponse<SendChatMessageResponse>> => {
+    const response = await apiClient.post<ApiResponse<RawSendChatMessageResponse>>(
+        `/api/v1/admin/chat/sessions/${sessionId}/messages`,
+        body,
+        { timeout: 90000 },
+    );
+    return {
+        ...response.data,
+        data: toChatMessageResponse(response.data.data),
+    };
+};
+
+/** 채팅 세션 종료 */
+export const endChatSessionApi = async (
+    sessionId: string,
+    body: EndChatSessionRequest,
+): Promise<ApiResponse<null>> => {
+    const response = await apiClient.post<ApiResponse<null>>(
+        `/api/v1/admin/chat/sessions/${sessionId}/end`,
+        body,
+    );
+    return response.data;
+};

--- a/src/api/endpoints/chat.ts
+++ b/src/api/endpoints/chat.ts
@@ -36,8 +36,12 @@ interface RawSendChatMessageResponse {
  * 백엔드 응답을 프론트 엔티티로 정규화
  */
 function toChatMessageResponse(raw: RawSendChatMessageResponse): SendChatMessageResponse {
+    const sessionId = raw.sessionId ?? raw.session_id;
+    if (!sessionId) {
+        throw new Error('Invalid chat response: missing sessionId');
+    }
     return {
-        sessionId: raw.sessionId ?? raw.session_id ?? '',
+        sessionId,
         answer: raw.answer,
         emotion: raw.emotion ?? null,
         language: raw.language ?? null,
@@ -71,7 +75,7 @@ export const createChatSessionApi = async (
     return response.data;
 };
 
-/** 채팅 메시지 전송 (AI 응답까지 최대 60초 소요) */
+/** 채팅 메시지 전송 (AI 응답까지 최대 90초 소요) */
 export const sendChatMessageApi = async (
     sessionId: string,
     body: SendChatMessageRequest,

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,6 +3,7 @@
 import { AuthGuard } from '@/features/auth/presentation/components/AuthGuard';
 import { AdminSidebarContainer } from '@/features/admin/presentation/components/AdminSidebarContainer';
 import { AdminHeader } from '@/shared/components/layout/AdminHeader';
+import { ChatWidget } from '@/features/chat/presentation/ChatWidget';
 
 export default function AdminLayout({
     children,
@@ -26,6 +27,7 @@ export default function AdminLayout({
                     </main>
                 </div>
             </div>
+            <ChatWidget />
         </AuthGuard>
     );
 }

--- a/src/features/chat/application/hooks/useChatSession.ts
+++ b/src/features/chat/application/hooks/useChatSession.ts
@@ -53,6 +53,7 @@ export function useChatSession(selectedDevice: Device | null): UseChatSessionRet
     const sessionIdRef = useRef<string | null>(null);
     const currentSiteIdRef = useRef<number | null>(currentSiteId);
     const selectedDeviceRef = useRef<Device | null>(selectedDevice);
+    const sendingRef = useRef(false);
 
     sessionIdRef.current = sessionId;
     currentSiteIdRef.current = currentSiteId;
@@ -79,13 +80,13 @@ export function useChatSession(selectedDevice: Device | null): UseChatSessionRet
         setError(null);
     }, [endSession]);
 
-    // 사이트 변경 시 세션 자동 리셋
+    // 사이트 또는 디바이스 변경 시 세션 자동 리셋
     useEffect(() => {
         if (sessionIdRef.current) {
             resetSession();
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [currentSiteId]);
+    }, [currentSiteId, selectedDevice?.deviceId]);
 
     // 언마운트 시 세션 종료
     useEffect(() => {
@@ -101,14 +102,17 @@ export function useChatSession(selectedDevice: Device | null): UseChatSessionRet
 
     const sendMessage = useCallback(
         async (text: string) => {
-            if (!text.trim() || isPending) return;
+            if (!text.trim() || sendingRef.current) return;
             if (currentSiteId === null || !selectedDevice) return;
 
+            sendingRef.current = true;
             setError(null);
             setIsPending(true);
 
             const userMessage = buildChatMessage('user', text);
             setMessages((previous) => [...previous, userMessage]);
+
+            let capturedSessionId: string | null = null;
 
             try {
                 let activeSessionId = sessionIdRef.current;
@@ -123,7 +127,10 @@ export function useChatSession(selectedDevice: Device | null): UseChatSessionRet
                     }
                     activeSessionId = sessionResponse.data.sessionId;
                     setSessionId(activeSessionId);
+                    sessionIdRef.current = activeSessionId;
                 }
+
+                capturedSessionId = activeSessionId;
 
                 const messageResponse = await sendChatMessageApi(activeSessionId, {
                     siteId: currentSiteId,
@@ -138,6 +145,9 @@ export function useChatSession(selectedDevice: Device | null): UseChatSessionRet
                     throw new Error(messageResponse.error?.message ?? 'AI 응답 수신에 실패했습니다.');
                 }
 
+                // 응답 대기 중 세션이 reset/변경됐으면 stale response 무시
+                if (sessionIdRef.current !== capturedSessionId) return;
+
                 const assistantMessage = buildChatMessage(
                     'assistant',
                     messageResponse.data.answer,
@@ -145,6 +155,7 @@ export function useChatSession(selectedDevice: Device | null): UseChatSessionRet
                 );
                 setMessages((previous) => [...previous, assistantMessage]);
             } catch (err) {
+                if (capturedSessionId !== null && sessionIdRef.current !== capturedSessionId) return;
                 const apiError = extractApiError(err);
                 setError(apiError);
                 const errorMessage = buildChatMessage(
@@ -153,10 +164,11 @@ export function useChatSession(selectedDevice: Device | null): UseChatSessionRet
                 );
                 setMessages((previous) => [...previous, errorMessage]);
             } finally {
+                sendingRef.current = false;
                 setIsPending(false);
             }
         },
-        [isPending, currentSiteId, selectedDevice],
+        [currentSiteId, selectedDevice],
     );
 
     return { messages, isPending, error, sendMessage, resetSession };

--- a/src/features/chat/application/hooks/useChatSession.ts
+++ b/src/features/chat/application/hooks/useChatSession.ts
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { ChatMessage, SendChatMessageResponse } from '@/features/chat/domain/entities/Chat';
+import { createChatSessionApi, sendChatMessageApi, endChatSessionApi } from '@/api/endpoints/chat';
+import { useSiteContext } from '@/features/auth/application/hooks/useAuth';
+import type { Device } from '@/features/device/domain/entities/Device';
+import type { ApiError } from '@/shared/types/api';
+import { extractApiError } from '@/shared/utils/api';
+
+interface UseChatSessionReturn {
+    messages: ChatMessage[];
+    isPending: boolean;
+    error: ApiError | null;
+    sendMessage: (text: string) => Promise<void>;
+    resetSession: () => Promise<void>;
+}
+
+function buildChatMessage(
+    role: ChatMessage['role'],
+    content: string,
+    response?: SendChatMessageResponse,
+): ChatMessage {
+    return {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        role,
+        content,
+        createdAt: new Date().toISOString(),
+        metadata: response
+            ? {
+                  emotion: response.emotion,
+                  language: response.language,
+                  category: response.category,
+                  placeId: response.placeId,
+                  placeName: response.placeName,
+                  imageUrl: response.imageUrl,
+                  deviceLatitude: response.deviceLatitude,
+                  deviceLongitude: response.deviceLongitude,
+                  answerLatitude: response.latitude,
+                  answerLongitude: response.longitude,
+              }
+            : null,
+    };
+}
+
+export function useChatSession(selectedDevice: Device | null): UseChatSessionReturn {
+    const [sessionId, setSessionId] = useState<string | null>(null);
+    const [messages, setMessages] = useState<ChatMessage[]>([]);
+    const [isPending, setIsPending] = useState(false);
+    const [error, setError] = useState<ApiError | null>(null);
+
+    const { currentSiteId } = useSiteContext();
+    const sessionIdRef = useRef<string | null>(null);
+    const currentSiteIdRef = useRef<number | null>(currentSiteId);
+    const selectedDeviceRef = useRef<Device | null>(selectedDevice);
+
+    sessionIdRef.current = sessionId;
+    currentSiteIdRef.current = currentSiteId;
+    selectedDeviceRef.current = selectedDevice;
+
+    const endSession = useCallback(async (targetSessionId: string, siteId: number, deviceId: string) => {
+        try {
+            await endChatSessionApi(targetSessionId, { siteId, deviceId });
+        } catch {
+            // 세션 종료 실패는 조용히 처리 (사용자 플로우에 영향 없음)
+        }
+    }, []);
+
+    const resetSession = useCallback(async () => {
+        const currentSession = sessionIdRef.current;
+        const siteId = currentSiteIdRef.current;
+        const device = selectedDeviceRef.current;
+
+        if (currentSession && siteId !== null && device) {
+            await endSession(currentSession, siteId, device.deviceId);
+        }
+        setSessionId(null);
+        setMessages([]);
+        setError(null);
+    }, [endSession]);
+
+    // 사이트 변경 시 세션 자동 리셋
+    useEffect(() => {
+        if (sessionIdRef.current) {
+            resetSession();
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [currentSiteId]);
+
+    // 언마운트 시 세션 종료
+    useEffect(() => {
+        return () => {
+            const currentSession = sessionIdRef.current;
+            const siteId = currentSiteIdRef.current;
+            const device = selectedDeviceRef.current;
+            if (currentSession && siteId !== null && device) {
+                endSession(currentSession, siteId, device.deviceId);
+            }
+        };
+    }, [endSession]);
+
+    const sendMessage = useCallback(
+        async (text: string) => {
+            if (!text.trim() || isPending) return;
+            if (currentSiteId === null || !selectedDevice) return;
+
+            setError(null);
+            setIsPending(true);
+
+            const userMessage = buildChatMessage('user', text);
+            setMessages((previous) => [...previous, userMessage]);
+
+            try {
+                let activeSessionId = sessionIdRef.current;
+
+                if (!activeSessionId) {
+                    const sessionResponse = await createChatSessionApi({
+                        siteId: currentSiteId,
+                        deviceId: selectedDevice.deviceId,
+                    });
+                    if (!sessionResponse.success) {
+                        throw new Error(sessionResponse.error?.message ?? '세션 생성에 실패했습니다.');
+                    }
+                    activeSessionId = sessionResponse.data.sessionId;
+                    setSessionId(activeSessionId);
+                }
+
+                const messageResponse = await sendChatMessageApi(activeSessionId, {
+                    siteId: currentSiteId,
+                    deviceId: selectedDevice.deviceId,
+                    message: text,
+                    language: 'ko-KR',
+                    latitude: selectedDevice.latitude,
+                    longitude: selectedDevice.longitude,
+                });
+
+                if (!messageResponse.success) {
+                    throw new Error(messageResponse.error?.message ?? 'AI 응답 수신에 실패했습니다.');
+                }
+
+                const assistantMessage = buildChatMessage(
+                    'assistant',
+                    messageResponse.data.answer,
+                    messageResponse.data,
+                );
+                setMessages((previous) => [...previous, assistantMessage]);
+            } catch (err) {
+                const apiError = extractApiError(err);
+                setError(apiError);
+                const errorMessage = buildChatMessage(
+                    'assistant',
+                    `AI 응답 실패: ${apiError.message}`,
+                );
+                setMessages((previous) => [...previous, errorMessage]);
+            } finally {
+                setIsPending(false);
+            }
+        },
+        [isPending, currentSiteId, selectedDevice],
+    );
+
+    return { messages, isPending, error, sendMessage, resetSession };
+}

--- a/src/features/chat/domain/entities/Chat.ts
+++ b/src/features/chat/domain/entities/Chat.ts
@@ -1,0 +1,66 @@
+/**
+ * Chat 도메인 엔티티
+ *
+ * Admin RAG LLM 채팅 테스트 기능에 사용되는 타입 정의
+ */
+
+export type ChatMessageRole = 'user' | 'assistant';
+
+export interface ChatMessageMetadata {
+    emotion: string | null;
+    language: string | null;
+    category: string | null;
+    placeId: number | null;
+    placeName: string | null;
+    imageUrl: string | null;
+    deviceLatitude: number | null;
+    deviceLongitude: number | null;
+    answerLatitude: number | null;
+    answerLongitude: number | null;
+}
+
+export interface ChatMessage {
+    id: string;
+    role: ChatMessageRole;
+    content: string;
+    createdAt: string;
+    metadata: ChatMessageMetadata | null;
+}
+
+export interface CreateChatSessionRequest {
+    siteId: number;
+    deviceId: string;
+}
+
+export interface CreateChatSessionResponse {
+    sessionId: string;
+}
+
+export interface SendChatMessageRequest {
+    siteId: number;
+    deviceId: string;
+    message: string;
+    language: string;
+    latitude?: number;
+    longitude?: number;
+}
+
+export interface SendChatMessageResponse {
+    sessionId: string;
+    answer: string;
+    emotion: string | null;
+    language: string | null;
+    category: string | null;
+    deviceLatitude: number | null;
+    deviceLongitude: number | null;
+    placeId: number | null;
+    placeName: string | null;
+    imageUrl: string | null;
+    latitude: number | null;
+    longitude: number | null;
+}
+
+export interface EndChatSessionRequest {
+    siteId: number;
+    deviceId: string;
+}

--- a/src/features/chat/presentation/ChatWidget.tsx
+++ b/src/features/chat/presentation/ChatWidget.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useState } from 'react';
+import { ChatFloatingButton } from './components/ChatFloatingButton';
+import { ChatPanel } from './components/ChatPanel';
+
+/** Admin 전역 AI 채팅 테스트 위젯 (FloatingButton + Panel 컨테이너) */
+export function ChatWidget() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const handleToggleChat = () => {
+        setIsOpen((previous) => !previous);
+    };
+
+    const handleCloseChat = () => {
+        setIsOpen(false);
+    };
+
+    return (
+        <>
+            <ChatPanel isOpen={isOpen} onClose={handleCloseChat} />
+            <ChatFloatingButton isOpen={isOpen} onToggle={handleToggleChat} />
+        </>
+    );
+}

--- a/src/features/chat/presentation/components/ChatDeviceSelector.tsx
+++ b/src/features/chat/presentation/components/ChatDeviceSelector.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { HiOutlineDeviceTablet, HiOutlineChevronDown } from 'react-icons/hi2';
+import type { ChatDeviceSelectorProps } from '@/features/chat/presentation/types/ChatDeviceSelectorProps';
+
+export function ChatDeviceSelector({
+    devices,
+    selectedDeviceId,
+    onSelectDevice,
+}: ChatDeviceSelectorProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const selectedDevice = devices.find((device) => device.deviceId === selectedDeviceId);
+
+    const handleSelectDevice = (deviceId: string) => {
+        onSelectDevice(deviceId);
+        setIsOpen(false);
+    };
+
+    if (devices.length === 0) {
+        return (
+            <span className="flex items-center gap-1 text-xs text-slate-400">
+                <HiOutlineDeviceTablet className="w-3.5 h-3.5 shrink-0" />
+                디바이스 없음
+            </span>
+        );
+    }
+
+    return (
+        <div className="relative">
+            <button
+                onClick={() => setIsOpen((previous) => !previous)}
+                className="flex items-center gap-1.5 bg-slate-50 hover:bg-white border border-slate-200 hover:border-orange-300 px-2.5 py-1.5 rounded-xl text-slate-700 transition-all group"
+            >
+                <HiOutlineDeviceTablet className="w-3.5 h-3.5 text-orange-500 shrink-0" />
+                <span className="text-xs font-semibold max-w-[120px] truncate">
+                    {selectedDevice ? selectedDevice.locationName : '디바이스 선택'}
+                </span>
+                <HiOutlineChevronDown
+                    className={`w-3.5 h-3.5 text-slate-400 group-hover:text-orange-500 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+                />
+            </button>
+
+            <AnimatePresence>
+                {isOpen && (
+                    <>
+                        <div
+                            className="fixed inset-0 z-[115]"
+                            onClick={() => setIsOpen(false)}
+                        />
+                        <motion.div
+                            initial={{ opacity: 0, y: -8, scale: 0.95 }}
+                            animate={{ opacity: 1, y: 0, scale: 1 }}
+                            exit={{ opacity: 0, y: -8, scale: 0.95 }}
+                            transition={{ duration: 0.15, ease: 'easeOut' }}
+                            className="absolute top-full left-0 mt-1.5 w-52 bg-white rounded-2xl py-1.5 z-[120] shadow-xl overflow-hidden border border-slate-100"
+                        >
+                            <div className="px-3.5 py-2 mb-0.5 border-b border-slate-100">
+                                <p className="text-[11px] font-bold text-slate-400 uppercase tracking-wide">
+                                    키오스크 선택
+                                </p>
+                            </div>
+                            <div className="max-h-48 overflow-y-auto">
+                                {devices.map((device) => (
+                                    <button
+                                        key={device.deviceId}
+                                        onClick={() => handleSelectDevice(device.deviceId)}
+                                        className={`w-full text-left px-3.5 py-2.5 text-xs font-semibold transition-all
+                                            ${selectedDeviceId === device.deviceId
+                                                ? 'bg-orange-50 text-orange-600'
+                                                : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900'
+                                            }`}
+                                    >
+                                        <span className="block truncate">{device.locationName}</span>
+                                        <span className="block text-[10px] font-normal text-slate-400 mt-0.5 truncate">
+                                            {device.deviceId}
+                                        </span>
+                                    </button>
+                                ))}
+                            </div>
+                        </motion.div>
+                    </>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+}

--- a/src/features/chat/presentation/components/ChatFloatingButton.tsx
+++ b/src/features/chat/presentation/components/ChatFloatingButton.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { HiOutlineChatBubbleLeftRight, HiOutlineXMark } from 'react-icons/hi2';
+import type { ChatFloatingButtonProps } from '@/features/chat/presentation/types/ChatFloatingButtonProps';
+
+/**
+ * 관리자 전역 AI 채팅 테스트 진입 버튼 (Neumorphism 입체감 스타일)
+ *
+ * Plastic style: inset highlight + drop shadow
+ * Metal style: conic-gradient 호버 전환으로 메탈릭 광택 표현
+ */
+export function ChatFloatingButton({ isOpen, onToggle }: ChatFloatingButtonProps) {
+    return (
+        <button
+            onClick={onToggle}
+            aria-label={isOpen ? 'AI 채팅 테스트 닫기' : 'AI 채팅 테스트 열기'}
+            className="
+                fixed bottom-6 right-6 z-[90]
+                w-14 h-14 rounded-full
+                flex items-center justify-center
+                text-white
+                transition-transform duration-200
+                hover:scale-105 active:scale-95
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2
+            "
+            style={{
+                background: isOpen
+                    ? 'conic-gradient(from 225deg, #FF8A6B, #FF6B52, #E5503A, #FF6B52, #FF8A6B)'
+                    : '#f97316',
+                boxShadow: `
+                    inset 0 2px 1px rgba(255, 255, 255, 1.0),
+                    inset 0 -2px 1px rgba(0, 0, 0, 0.1),
+                    0 8px 24px rgba(255, 107, 82, 0.4)
+                `,
+            }}
+        >
+            {isOpen ? (
+                <HiOutlineXMark className="w-6 h-6" />
+            ) : (
+                <HiOutlineChatBubbleLeftRight className="w-6 h-6" />
+            )}
+        </button>
+    );
+}

--- a/src/features/chat/presentation/components/ChatMessageBubble.tsx
+++ b/src/features/chat/presentation/components/ChatMessageBubble.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import Image from 'next/image';
+import type { ChatMessageBubbleProps } from '@/features/chat/presentation/types/ChatMessageBubbleProps';
+
+const EMOTION_LABEL: Record<string, string> = {
+    GUIDING: '안내',
+    NEUTRAL: '일반',
+    HAPPY: '기쁨',
+    CURIOUS: '호기심',
+    SORRY: '사과',
+};
+
+const CATEGORY_LABEL: Record<string, string> = {
+    DIRECTION: '길안내',
+    INFO: '정보',
+    RECOMMENDATION: '추천',
+    GREETING: '인사',
+    UNKNOWN: '기타',
+};
+
+export function ChatMessageBubble({ message }: ChatMessageBubbleProps) {
+    const isUser = message.role === 'user';
+    const { metadata } = message;
+
+    return (
+        <div className={`flex items-end gap-2 mb-3 ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
+            {!isUser && (
+                <div className="w-7 h-7 rounded-full bg-orange-100 flex items-center justify-center shrink-0 text-orange-500 text-xs font-bold">
+                    AI
+                </div>
+            )}
+
+            <div className={`flex flex-col gap-1 max-w-[75%] ${isUser ? 'items-end' : 'items-start'}`}>
+                <div
+                    className={`
+                        px-3.5 py-2.5 rounded-2xl text-sm leading-relaxed break-words
+                        ${isUser
+                            ? 'bg-orange-500 text-white rounded-br-sm'
+                            : 'bg-white border border-slate-100 text-slate-800 rounded-bl-sm shadow-sm'
+                        }
+                    `}
+                >
+                    {message.content}
+                </div>
+
+                {!isUser && metadata && (
+                    <>
+                        {metadata.imageUrl && (
+                            <div className="relative w-full h-32 rounded-xl overflow-hidden mt-1">
+                                <Image
+                                    src={metadata.imageUrl}
+                                    alt={metadata.placeName ?? '장소 이미지'}
+                                    fill
+                                    className="object-cover"
+                                />
+                            </div>
+                        )}
+
+                        <div className="flex flex-wrap gap-1 mt-0.5">
+                            {metadata.emotion && (
+                                <span className="px-2 py-0.5 rounded-full bg-orange-50 text-orange-600 text-xs border border-orange-100">
+                                    {EMOTION_LABEL[metadata.emotion] ?? metadata.emotion}
+                                </span>
+                            )}
+                            {metadata.category && (
+                                <span className="px-2 py-0.5 rounded-full bg-slate-50 text-slate-500 text-xs border border-slate-200">
+                                    {CATEGORY_LABEL[metadata.category] ?? metadata.category}
+                                </span>
+                            )}
+                            {metadata.placeName && (
+                                <span className="px-2 py-0.5 rounded-full bg-blue-50 text-blue-600 text-xs border border-blue-100">
+                                    📍 {metadata.placeName}
+                                </span>
+                            )}
+                        </div>
+                    </>
+                )}
+
+                <span className="text-[10px] text-slate-400 px-1">
+                    {new Date(message.createdAt).toLocaleTimeString('ko-KR', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                    })}
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/src/features/chat/presentation/components/ChatPanel.tsx
+++ b/src/features/chat/presentation/components/ChatPanel.tsx
@@ -33,11 +33,17 @@ export function ChatPanel({ isOpen, onClose }: ChatPanelProps) {
         await resetSession();
     };
 
-    // 디바이스 변경 시 세션 리셋
-    const handleSelectDevice = async (deviceId: string) => {
+    // 디바이스 변경 — reset은 useChatSession deps 변경으로 자동 처리
+    const handleSelectDevice = (deviceId: string) => {
         setSelectedDeviceId(deviceId);
-        await resetSession();
     };
+
+    // 패널 닫힐 때 세션 종료 (FAB 토글·X 버튼 모두 동일 경로)
+    useEffect(() => {
+        if (!isOpen) {
+            resetSession();
+        }
+    }, [isOpen, resetSession]);
 
     // 새 메시지 도착 시 스크롤 하단 이동
     useEffect(() => {
@@ -59,8 +65,11 @@ export function ChatPanel({ isOpen, onClose }: ChatPanelProps) {
     };
 
     const handleCloseChat = async () => {
-        await resetSession();
-        onClose();
+        try {
+            await resetSession();
+        } finally {
+            onClose();
+        }
     };
 
     const handleResetSession = async () => {
@@ -87,12 +96,14 @@ export function ChatPanel({ isOpen, onClose }: ChatPanelProps) {
                                 <button
                                     onClick={handleResetSession}
                                     title="대화 초기화"
+                                    aria-label="대화 초기화"
                                     className="p-1.5 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors"
                                 >
                                     <HiOutlineArrowPath className="w-4 h-4" />
                                 </button>
                                 <button
                                     onClick={handleCloseChat}
+                                    aria-label="채팅 패널 닫기"
                                     className="p-1.5 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors"
                                 >
                                     <HiOutlineXMark className="w-4 h-4" />
@@ -164,6 +175,7 @@ export function ChatPanel({ isOpen, onClose }: ChatPanelProps) {
                             <button
                                 onClick={handleSendMessage}
                                 disabled={!inputText.trim() || isPending || !isReady}
+                                aria-label="메시지 전송"
                                 className="w-9 h-9 rounded-xl bg-orange-500 text-white flex items-center justify-center shrink-0 hover:bg-orange-600 active:bg-orange-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                             >
                                 <HiOutlinePaperAirplane className="w-4 h-4" />

--- a/src/features/chat/presentation/components/ChatPanel.tsx
+++ b/src/features/chat/presentation/components/ChatPanel.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { HiOutlineXMark, HiOutlinePaperAirplane, HiOutlineArrowPath } from 'react-icons/hi2';
+import { useDevices } from '@/features/device/application/hooks/useDevices';
+import { useAuth, useSiteContext } from '@/features/auth/application/hooks/useAuth';
+import { useChatSession } from '@/features/chat/application/hooks/useChatSession';
+import { ChatMessageBubble } from './ChatMessageBubble';
+import { ChatTypingIndicator } from './ChatTypingIndicator';
+import { ChatDeviceSelector } from './ChatDeviceSelector';
+import { ChatSiteSelector } from './ChatSiteSelector';
+import type { ChatPanelProps } from '@/features/chat/presentation/types/ChatPanelProps';
+
+export function ChatPanel({ isOpen, onClose }: ChatPanelProps) {
+    const [inputText, setInputText] = useState('');
+    const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+    const messagesEndRef = useRef<HTMLDivElement>(null);
+
+    const { isPlatformAdmin } = useAuth();
+    const { sites, currentSiteId, setCurrentSite } = useSiteContext();
+    const { filteredDevices } = useDevices();
+
+    // 선택된 디바이스가 없으면 첫 번째 활성 디바이스를 기본값으로 사용
+    const effectiveDeviceId = selectedDeviceId ?? filteredDevices[0]?.deviceId ?? null;
+    const selectedDevice = filteredDevices.find((device) => device.deviceId === effectiveDeviceId) ?? null;
+    const { messages, isPending, sendMessage, resetSession } = useChatSession(selectedDevice);
+
+    // 사이트 변경 시 디바이스 선택 초기화
+    const handleSelectSite = async (siteId: number) => {
+        setCurrentSite(siteId);
+        setSelectedDeviceId(null);
+        await resetSession();
+    };
+
+    // 디바이스 변경 시 세션 리셋
+    const handleSelectDevice = async (deviceId: string) => {
+        setSelectedDeviceId(deviceId);
+        await resetSession();
+    };
+
+    // 새 메시지 도착 시 스크롤 하단 이동
+    useEffect(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, [messages, isPending]);
+
+    const handleSendMessage = async () => {
+        if (!inputText.trim() || isPending || !selectedDevice) return;
+        const text = inputText;
+        setInputText('');
+        await sendMessage(text);
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (event.key === 'Enter' && !event.shiftKey) {
+            event.preventDefault();
+            handleSendMessage();
+        }
+    };
+
+    const handleCloseChat = async () => {
+        await resetSession();
+        onClose();
+    };
+
+    const handleResetSession = async () => {
+        await resetSession();
+    };
+
+    const isReady = !!currentSiteId && !!selectedDevice;
+
+    return (
+        <AnimatePresence>
+            {isOpen && (
+                <motion.div
+                    initial={{ opacity: 0, scale: 0.95, y: 16 }}
+                    animate={{ opacity: 1, scale: 1, y: 0 }}
+                    exit={{ opacity: 0, scale: 0.95, y: 16 }}
+                    transition={{ duration: 0.2 }}
+                    className="fixed bottom-24 right-6 z-[110] w-[360px] h-[580px] bg-white rounded-2xl shadow-2xl border border-slate-100 flex flex-col overflow-hidden"
+                >
+                    {/* 헤더 */}
+                    <div className="px-4 pt-3.5 pb-3 border-b border-slate-100 shrink-0 bg-white">
+                        <div className="flex items-center justify-between mb-2.5">
+                            <span className="text-sm font-bold text-slate-800">AI 채팅 테스트</span>
+                            <div className="flex items-center gap-1">
+                                <button
+                                    onClick={handleResetSession}
+                                    title="대화 초기화"
+                                    className="p-1.5 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors"
+                                >
+                                    <HiOutlineArrowPath className="w-4 h-4" />
+                                </button>
+                                <button
+                                    onClick={handleCloseChat}
+                                    className="p-1.5 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors"
+                                >
+                                    <HiOutlineXMark className="w-4 h-4" />
+                                </button>
+                            </div>
+                        </div>
+
+                        {/* 관광지 + 디바이스 선택 행 */}
+                        <div className="flex items-center gap-2 flex-wrap">
+                            {isPlatformAdmin && (
+                                <ChatSiteSelector
+                                    sites={sites}
+                                    currentSiteId={currentSiteId}
+                                    onSelectSite={handleSelectSite}
+                                />
+                            )}
+                            <ChatDeviceSelector
+                                devices={filteredDevices}
+                                selectedDeviceId={effectiveDeviceId}
+                                onSelectDevice={handleSelectDevice}
+                            />
+                        </div>
+                    </div>
+
+                    {/* 메시지 목록 */}
+                    <div className="flex-1 overflow-y-auto px-4 py-3 bg-slate-50">
+                        {messages.length === 0 && !isPending && (
+                            <div className="h-full flex flex-col items-center justify-center text-center text-slate-400 gap-2">
+                                <span className="text-3xl">💬</span>
+                                <p className="text-sm">
+                                    {!currentSiteId
+                                        ? '관광지를 먼저 선택해주세요.'
+                                        : !isReady
+                                          ? '디바이스를 선택해주세요.'
+                                          : '질문을 입력해 AI 응답을 테스트해보세요.'}
+                                </p>
+                            </div>
+                        )}
+
+                        {messages.map((message) => (
+                            <ChatMessageBubble key={message.id} message={message} />
+                        ))}
+
+                        {isPending && <ChatTypingIndicator />}
+
+                        <div ref={messagesEndRef} />
+                    </div>
+
+                    {/* 입력 영역 */}
+                    <div className="px-3 py-3 border-t border-slate-100 bg-white shrink-0">
+                        <div className="flex items-end gap-2">
+                            <textarea
+                                value={inputText}
+                                onChange={(event) => setInputText(event.target.value)}
+                                onKeyDown={handleKeyDown}
+                                disabled={isPending || !isReady}
+                                placeholder={
+                                    !currentSiteId
+                                        ? '관광지를 선택해주세요'
+                                        : !isReady
+                                          ? '디바이스를 선택해주세요'
+                                          : isPending
+                                            ? 'AI가 응답 중입니다...'
+                                            : '메시지를 입력하세요 (Enter 전송)'
+                                }
+                                rows={1}
+                                className="flex-1 resize-none rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-orange-300 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed max-h-24 overflow-y-auto"
+                            />
+                            <button
+                                onClick={handleSendMessage}
+                                disabled={!inputText.trim() || isPending || !isReady}
+                                className="w-9 h-9 rounded-xl bg-orange-500 text-white flex items-center justify-center shrink-0 hover:bg-orange-600 active:bg-orange-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                            >
+                                <HiOutlinePaperAirplane className="w-4 h-4" />
+                            </button>
+                        </div>
+                    </div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+}

--- a/src/features/chat/presentation/components/ChatSiteSelector.tsx
+++ b/src/features/chat/presentation/components/ChatSiteSelector.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { HiOutlineBuildingOffice2, HiOutlineChevronDown } from 'react-icons/hi2';
+import type { ChatSiteSelectorProps } from '@/features/chat/presentation/types/ChatSiteSelectorProps';
+
+export function ChatSiteSelector({
+    sites,
+    currentSiteId,
+    onSelectSite,
+}: ChatSiteSelectorProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const currentSite = sites.find((site) => site.siteId === currentSiteId);
+
+    const handleSelectSite = (siteId: number) => {
+        onSelectSite(siteId);
+        setIsOpen(false);
+    };
+
+    return (
+        <div className="relative">
+            <button
+                onClick={() => setIsOpen((previous) => !previous)}
+                className="flex items-center gap-1.5 bg-orange-50 hover:bg-orange-100 border border-orange-200 hover:border-orange-400 px-2.5 py-1.5 rounded-xl text-orange-700 transition-all group"
+            >
+                <HiOutlineBuildingOffice2 className="w-3.5 h-3.5 text-orange-500 shrink-0" />
+                <span className="text-xs font-bold max-w-[100px] truncate">
+                    {currentSite ? currentSite.name : '관광지 선택'}
+                </span>
+                <HiOutlineChevronDown
+                    className={`w-3.5 h-3.5 text-orange-400 group-hover:text-orange-600 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+                />
+            </button>
+
+            <AnimatePresence>
+                {isOpen && (
+                    <>
+                        <div
+                            className="fixed inset-0 z-[115]"
+                            onClick={() => setIsOpen(false)}
+                        />
+                        <motion.div
+                            initial={{ opacity: 0, y: -8, scale: 0.95 }}
+                            animate={{ opacity: 1, y: 0, scale: 1 }}
+                            exit={{ opacity: 0, y: -8, scale: 0.95 }}
+                            transition={{ duration: 0.15, ease: 'easeOut' }}
+                            className="absolute top-full left-0 mt-1.5 w-52 bg-white rounded-2xl py-1.5 z-[120] shadow-xl overflow-hidden border border-slate-100"
+                        >
+                            <div className="px-3.5 py-2 mb-0.5 border-b border-slate-100">
+                                <p className="text-[11px] font-bold text-slate-400 uppercase tracking-wide">
+                                    관광지 전환
+                                </p>
+                            </div>
+                            <div className="max-h-60 overflow-y-auto">
+                                {sites.map((site) => (
+                                    <button
+                                        key={site.siteId}
+                                        onClick={() => handleSelectSite(site.siteId)}
+                                        className={`w-full text-left px-3.5 py-2.5 text-xs font-bold transition-all flex items-center justify-between gap-2
+                                            ${currentSiteId === site.siteId
+                                                ? 'bg-orange-50 text-orange-600'
+                                                : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900'
+                                            }`}
+                                    >
+                                        <span className="truncate">{site.name}</span>
+                                        {!site.isActive && (
+                                            <span className="text-[10px] font-normal text-slate-400 shrink-0">
+                                                비활성
+                                            </span>
+                                        )}
+                                    </button>
+                                ))}
+                            </div>
+                        </motion.div>
+                    </>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+}

--- a/src/features/chat/presentation/components/ChatTypingIndicator.tsx
+++ b/src/features/chat/presentation/components/ChatTypingIndicator.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+/** AI 응답 대기 중 표시하는 3-dot wave 인디케이터 */
+export function ChatTypingIndicator() {
+    return (
+        <div className="flex items-start gap-2 mb-3">
+            <div className="w-7 h-7 rounded-full bg-orange-100 flex items-center justify-center shrink-0 text-orange-500 text-xs font-bold">
+                AI
+            </div>
+            <div className="bg-white border border-slate-100 rounded-2xl rounded-tl-sm px-4 py-3 shadow-sm">
+                <div className="flex items-center gap-1.5">
+                    <span
+                        className="w-2 h-2 rounded-full bg-slate-400 animate-bounce"
+                        style={{ animationDelay: '0ms' }}
+                    />
+                    <span
+                        className="w-2 h-2 rounded-full bg-slate-400 animate-bounce"
+                        style={{ animationDelay: '150ms' }}
+                    />
+                    <span
+                        className="w-2 h-2 rounded-full bg-slate-400 animate-bounce"
+                        style={{ animationDelay: '300ms' }}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/features/chat/presentation/types/ChatDeviceSelectorProps.ts
+++ b/src/features/chat/presentation/types/ChatDeviceSelectorProps.ts
@@ -1,0 +1,7 @@
+import type { Device } from '@/features/device/domain/entities/Device';
+
+export interface ChatDeviceSelectorProps {
+    devices: Device[];
+    selectedDeviceId: string | null;
+    onSelectDevice: (deviceId: string) => void;
+}

--- a/src/features/chat/presentation/types/ChatFloatingButtonProps.ts
+++ b/src/features/chat/presentation/types/ChatFloatingButtonProps.ts
@@ -1,0 +1,4 @@
+export interface ChatFloatingButtonProps {
+    isOpen: boolean;
+    onToggle: () => void;
+}

--- a/src/features/chat/presentation/types/ChatMessageBubbleProps.ts
+++ b/src/features/chat/presentation/types/ChatMessageBubbleProps.ts
@@ -1,0 +1,5 @@
+import type { ChatMessage } from '@/features/chat/domain/entities/Chat';
+
+export interface ChatMessageBubbleProps {
+    message: ChatMessage;
+}

--- a/src/features/chat/presentation/types/ChatPanelProps.ts
+++ b/src/features/chat/presentation/types/ChatPanelProps.ts
@@ -1,0 +1,4 @@
+export interface ChatPanelProps {
+    isOpen: boolean;
+    onClose: () => void;
+}

--- a/src/features/chat/presentation/types/ChatSiteSelectorProps.ts
+++ b/src/features/chat/presentation/types/ChatSiteSelectorProps.ts
@@ -1,0 +1,7 @@
+import type { Site } from '@/features/auth/application/store/AuthContext';
+
+export interface ChatSiteSelectorProps {
+    sites: Site[];
+    currentSiteId: number | null;
+    onSelectSite: (siteId: number) => void;
+}

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -44,7 +44,8 @@ export type ErrorCode =
     | 'RATE_LIMITED'                // 429 과다 요청
     | 'DOC_UPLOAD_FAILED'           // 500 파일 업로드 실패
     | 'INTERNAL_ERROR'              // 500 서버 오류
-    | 'UPSTREAM_TIMEOUT';           // 503 외부 의존 장애
+    | 'UPSTREAM_TIMEOUT'            // 503 외부 의존 장애
+    | 'FEIGN_ERROR';                // 500 Core/FastAPI 타임아웃
 
 /**
  * 페이지네이션 응답 (v4.0)


### PR DESCRIPTION
# 🔀 PR 요약
- resolves #74
- 관리자 웹에 LLM 채팅 테스트 기능을 추가 했습니다.

## ✨ 변경 내용
- `chat` 피처 모듈 신규 구현 (domain → application → presentation Clean Architecture)
- 채팅 세션 생성 / 메시지 송수신 / 세션 종료 API 연동
- 모든 `/admin/*` 페이지 우하단에 Neumorphism 입체감 플로팅 버튼 추가
- FAB 클릭 시 메신저 스타일 채팅 카드 슬라이드업 (framer-motion)
- PLATFORM_ADMIN: 관광지 선택 드롭다운 표시 — 사이트 전환 가능
- SITE_ADMIN: 소속 관광지 자동 고정
- 디바이스 드롭다운 — `locationName` 라벨 / `deviceId` 서브텍스트 표시, 애니메이션        
- AI 응답 대기 중 typing indicator (3-dot wave)
- 응답에 `emotion` / `category` / `placeName` 메타 chip 표시
- 사이트·디바이스 변경 및 패널 닫기 시 세션 자동 종료 (`/end` 호출)
- `ErrorCode`에 `FEIGN_ERROR` 추가 (Core/FastAPI 타임아웃 케이스 대응)

## 🖼️ 스크린샷 (UI 변경 시 필수)
<img width="380" height="653" alt="image" src="https://github.com/user-attachments/assets/435b5080-e25d-49f4-ab35-7db3cf144eb8" />


## 🔍 주요 포인트
- 

## 🧪 테스트
- [X] 로컬에서 빌드 및 실행 확인
- [X] 주요 기능 동작 확인 (크롬 개발자 도구)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자 화면에 AI 채팅 위젯 추가 (플로팅 버튼으로 언제든 활성화 가능)
  * 채팅 세션별 메시지 관리 및 실시간 송수신 기능
  * 디바이스 및 관광지 선택 기능 통합
  * AI 응답 시 감정, 카테고리, 위치 정보 등 메타데이터 표시

* **Improvements**
  * API 에러 처리 코드 확대

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-Guideon/guideon-frontend/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->