### PR TITLE
Feat/mascot voice cloning

### DIFF
--- a/src/api/endpoints/mascot.ts
+++ b/src/api/endpoints/mascot.ts
@@ -6,7 +6,9 @@ import type {
     UpdateMascotRequest,
     MascotGenerationStart,
     MascotGenerationStatus,
+    MascotVoiceCloneResult,
 } from '@/features/mascot/domain/entities/Mascot';
+import { VOICE_CLONE_DEFAULT_LANGUAGE } from '@/features/mascot/domain/entities/Mascot';
 
 /**
  * Mascot Image Upload 응답 타입
@@ -19,13 +21,14 @@ export interface MascotImageResponse {
 /**
  * Mascot API Endpoints (PLATFORM_ADMIN 전용)
  *
- * POST  /admin/sites/{siteId}/mascot                              - 생성
- * GET   /admin/sites/{siteId}/mascot                              - 조회
- * PATCH /admin/sites/{siteId}/mascot                              - 수정
- * POST  /admin/sites/{siteId}/mascot/image                        - 이미지 선업로드 (multipart)
- * POST  /admin/sites/{siteId}/mascot/generate                     - 3D 생성 시작 (JSON)
- * GET   /admin/sites/{siteId}/mascot/generate/{generationId}/status - 상태 폴링
- * GET   /admin/sites/{siteId}/mascot/generate/latest              - 최근 이력
+ * POST  /admin/sites/{siteId}/mascot                                    - 생성
+ * GET   /admin/sites/{siteId}/mascot                                    - 조회
+ * PATCH /admin/sites/{siteId}/mascot                                    - 수정
+ * POST  /admin/sites/{siteId}/mascot/image                              - 이미지 선업로드 (multipart)
+ * POST  /admin/sites/{siteId}/mascot/generate                           - 3D 생성 시작 (JSON)
+ * GET   /admin/sites/{siteId}/mascot/generate/{generationId}/status     - 상태 폴링
+ * GET   /admin/sites/{siteId}/mascot/generate/latest                    - 최근 이력
+ * POST  /admin/sites/{siteId}/mascot/voice/clone                        - Cartesia 음성 클로닝 (multipart)
  */
 
 /**
@@ -110,6 +113,28 @@ export const getMascotGenerationStatusApi = async (siteId: number, generationId:
 export const getMascotGenerationLatestApi = async (siteId: number) => {
     const response = await apiClient.get<ApiResponse<MascotGenerationStatus>>(
         `/admin/sites/${siteId}/mascot/generate/latest`,
+    );
+    return response.data;
+};
+
+/**
+ * Cartesia 음성 클로닝 (multipart/form-data)
+ * Content-Type 헤더는 Axios가 FormData를 감지해 자동 설정 — 직접 지정 금지
+ */
+export const cloneMascotVoiceApi = async (
+    siteId: number,
+    file: File,
+    name: string,
+    language: string = VOICE_CLONE_DEFAULT_LANGUAGE,
+): Promise<ApiResponse<MascotVoiceCloneResult>> => {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('name', name);
+    formData.append('language', language);
+
+    const response = await apiClient.post<ApiResponse<MascotVoiceCloneResult>>(
+        `/admin/sites/${siteId}/mascot/voice/clone`,
+        formData,
     );
     return response.data;
 };

--- a/src/api/endpoints/mascot.ts
+++ b/src/api/endpoints/mascot.ts
@@ -135,6 +135,7 @@ export const cloneMascotVoiceApi = async (
     const response = await apiClient.post<ApiResponse<MascotVoiceCloneResult>>(
         `/admin/sites/${siteId}/mascot/voice/clone`,
         formData,
+        { timeout: 60000 },
     );
     return response.data;
 };

--- a/src/features/mascot/application/hooks/useMascotVoiceClone.ts
+++ b/src/features/mascot/application/hooks/useMascotVoiceClone.ts
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState, useCallback, useRef } from 'react';
+import type { ApiError } from '@/shared/types/api';
+import type { MascotVoiceCloneResult } from '@/features/mascot/domain/entities/Mascot';
+import {
+    VOICE_CLONE_MAX_BYTES,
+    VOICE_CLONE_ACCEPTED_EXTENSIONS,
+    VOICE_CLONE_DEFAULT_LANGUAGE,
+} from '@/features/mascot/domain/entities/Mascot';
+import { cloneMascotVoiceApi } from '@/api/endpoints/mascot';
+import { extractApiError } from '@/shared/utils/api';
+
+interface UseMascotVoiceCloneReturn {
+    cloneVoice: (file: File, name: string) => Promise<MascotVoiceCloneResult | null>;
+    isCloning: boolean;
+    error: ApiError | null;
+    resetError: () => void;
+}
+
+export function useMascotVoiceClone(siteId: number | null): UseMascotVoiceCloneReturn {
+    const [isCloning, setIsCloning] = useState(false);
+    const [error, setError] = useState<ApiError | null>(null);
+    const cloningRef = useRef(false);
+
+    const resetError = useCallback(() => setError(null), []);
+
+    const cloneVoice = useCallback(async (
+        file: File,
+        name: string,
+    ): Promise<MascotVoiceCloneResult | null> => {
+        if (!siteId || cloningRef.current) return null;
+
+        // 클라이언트 사전 검증
+        const rawExtension = file.name.split('.').pop()?.toLowerCase() ?? '';
+        const extension = `.${rawExtension}` as typeof VOICE_CLONE_ACCEPTED_EXTENSIONS[number];
+        const isAccepted = (VOICE_CLONE_ACCEPTED_EXTENSIONS as readonly string[]).includes(extension);
+
+        if (!isAccepted) {
+            setError({
+                code: 'VALIDATION_ERROR',
+                message: `지원하지 않는 파일 형식입니다. (${VOICE_CLONE_ACCEPTED_EXTENSIONS.join(', ')})`,
+            });
+            return null;
+        }
+        if (file.size > VOICE_CLONE_MAX_BYTES) {
+            setError({
+                code: 'VALIDATION_ERROR',
+                message: '파일이 너무 큽니다. 10초(약 800KB) 이하 파일을 사용해 주세요.',
+            });
+            return null;
+        }
+        if (!name.trim()) {
+            setError({
+                code: 'VALIDATION_ERROR',
+                message: '보이스 이름을 입력해 주세요.',
+            });
+            return null;
+        }
+
+        cloningRef.current = true;
+        setIsCloning(true);
+        setError(null);
+
+        try {
+            const response = await cloneMascotVoiceApi(
+                siteId,
+                file,
+                name.trim(),
+                VOICE_CLONE_DEFAULT_LANGUAGE,
+            );
+            return response.data;
+        } catch (err: unknown) {
+            const apiError = extractApiError(err);
+            const httpStatus = (err as { response?: { status?: number } })?.response?.status;
+
+            if (httpStatus === 503) {
+                setError({
+                    ...apiError,
+                    message: '음성 클로닝 서비스 설정이 필요합니다. 관리자에게 문의해 주세요.',
+                });
+            } else if (apiError.code === 'MASCOT_NOT_FOUND') {
+                setError({ ...apiError, message: '마스코트를 먼저 등록해 주세요.' });
+            } else if (apiError.code === 'VOICE_CLONE_FAILED') {
+                setError({ ...apiError, message: '잠시 후 다시 시도해 주세요.' });
+            } else if (apiError.code === 'VALIDATION_ERROR') {
+                setError({
+                    ...apiError,
+                    message: '파일 형식이 올바르지 않거나 10초를 초과합니다.',
+                });
+            } else {
+                setError(apiError);
+            }
+            return null;
+        } finally {
+            cloningRef.current = false;
+            setIsCloning(false);
+        }
+    }, [siteId]);
+
+    return { cloneVoice, isCloning, error, resetError };
+}

--- a/src/features/mascot/domain/entities/Mascot.ts
+++ b/src/features/mascot/domain/entities/Mascot.ts
@@ -49,7 +49,7 @@ export interface CreateMascotRequest {
     greetingMsg: string;
     systemPrompt: string;
     promptConfig?: PromptConfig;
-    ttsVoiceId: string;
+    ttsVoiceId?: string;
     ttsVoiceJson?: TtsVoiceConfig;
 }
 
@@ -108,7 +108,7 @@ export const DEFAULT_ANIM_OPTIONS = [
 ] as const;
 
 /**
- * TTS 음성 옵션
+ * TTS 음성 옵션 (Deprecated: Cartesia 클로닝으로 대체됨)
  */
 export const TTS_VOICE_OPTIONS = [
     { value: 'ko-KR-Wavenet-A', label: '한국어 여성 A' },
@@ -116,3 +116,19 @@ export const TTS_VOICE_OPTIONS = [
     { value: 'ko-KR-Wavenet-C', label: '한국어 남성 A' },
     { value: 'ko-KR-Wavenet-D', label: '한국어 남성 B' },
 ] as const;
+
+/**
+ * 음성 클로닝 결과
+ */
+export interface MascotVoiceCloneResult {
+    voiceId: string;
+    name: string;
+}
+
+export const VOICE_CLONE_ACCEPTED_EXTENSIONS = [
+    '.wav', '.mp3', '.m4a', '.m4r', '.ogg', '.webm',
+] as const;
+
+export const VOICE_CLONE_ACCEPT_ATTRIBUTE = VOICE_CLONE_ACCEPTED_EXTENSIONS.join(',');
+export const VOICE_CLONE_MAX_BYTES = 800 * 1024;
+export const VOICE_CLONE_DEFAULT_LANGUAGE = 'ko';

--- a/src/features/mascot/presentation/components/MascotFormModal.tsx
+++ b/src/features/mascot/presentation/components/MascotFormModal.tsx
@@ -13,9 +13,9 @@ import type {
     CreateMascotRequest,
     UpdateMascotRequest,
 } from '@/features/mascot/domain/entities/Mascot';
-import { DEFAULT_ANIM_OPTIONS, TTS_VOICE_OPTIONS } from '@/features/mascot/domain/entities/Mascot';
+import { DEFAULT_ANIM_OPTIONS } from '@/features/mascot/domain/entities/Mascot';
 
-type FormTab = 'basic' | 'prompt' | 'tts';
+type FormTab = 'basic' | 'prompt';
 
 interface MascotFormModalProps {
     isOpen: boolean;
@@ -31,7 +31,6 @@ interface MascotFormModalProps {
 const TABS: { id: FormTab; label: string }[] = [
     { id: 'basic', label: '기본 정보' },
     { id: 'prompt', label: 'AI 프롬프트' },
-    { id: 'tts', label: 'TTS 음성' },
 ];
 
 /**
@@ -64,14 +63,8 @@ export function MascotFormModal({
     const [smalltalkStyle, setSmalltalkStyle] = useState('');
     const [answerStyle, setAnswerStyle] = useState('');
 
-    // TTS 음성
-    const [ttsVoiceId, setTtsVoiceId] = useState('ko-KR-Wavenet-A');
-    const [ttsSpeed, setTtsSpeed] = useState('1.0');
-    const [ttsPitch, setTtsPitch] = useState('0');
-
     // 드롭다운 상태
     const [isAnimDropdownOpen, setIsAnimDropdownOpen] = useState(false);
-    const [isVoiceDropdownOpen, setIsVoiceDropdownOpen] = useState(false);
 
     // 모달 열릴 때 초기화
     useEffect(() => {
@@ -88,9 +81,6 @@ export function MascotFormModal({
             setBasePersona(editTarget.promptConfig?.base_persona ?? '');
             setSmalltalkStyle(editTarget.promptConfig?.smalltalk_style ?? '');
             setAnswerStyle(editTarget.promptConfig?.answer_style ?? '');
-            setTtsVoiceId(editTarget.ttsVoiceId);
-            setTtsSpeed(String(editTarget.ttsVoiceJson?.speed ?? '1.0'));
-            setTtsPitch(String(editTarget.ttsVoiceJson?.pitch ?? '0'));
         } else {
             setName('');
             setModelId('');
@@ -101,9 +91,6 @@ export function MascotFormModal({
             setBasePersona('');
             setSmalltalkStyle('');
             setAnswerStyle('');
-            setTtsVoiceId('ko-KR-Wavenet-A');
-            setTtsSpeed('1.0');
-            setTtsPitch('0');
         }
     }, [isOpen, mode, editTarget, initialTab]);
 
@@ -125,15 +112,6 @@ export function MascotFormModal({
         return Object.keys(config).length > 0 ? config : undefined;
     };
 
-    const buildTtsVoiceJson = () => {
-        const speed = parseFloat(ttsSpeed);
-        const pitch = parseFloat(ttsPitch);
-        const json: Record<string, number> = {};
-        if (!isNaN(speed) && speed !== 1.0) json.speed = speed;
-        if (!isNaN(pitch) && pitch !== 0) json.pitch = pitch;
-        return Object.keys(json).length > 0 ? json : undefined;
-    };
-
     const handleSubmit = (event: FormEvent) => {
         event.preventDefault();
 
@@ -145,8 +123,6 @@ export function MascotFormModal({
                 greetingMsg: greetingMsg.trim(),
                 systemPrompt: systemPrompt.trim(),
                 promptConfig: buildPromptConfig(),
-                ttsVoiceId,
-                ttsVoiceJson: buildTtsVoiceJson(),
             };
             onSubmit(request);
         } else {
@@ -157,8 +133,6 @@ export function MascotFormModal({
                 greetingMsg: greetingMsg.trim(),
                 systemPrompt: systemPrompt.trim(),
                 promptConfig: buildPromptConfig(),
-                ttsVoiceId,
-                ttsVoiceJson: buildTtsVoiceJson(),
                 isActive,
             };
             onSubmit(request);
@@ -418,105 +392,6 @@ export function MascotFormModal({
                                         </>
                                     )}
 
-                                    {/* TTS 음성 탭 */}
-                                    {activeTab === 'tts' && (
-                                        <>
-                                            {/* 음성 선택 드롭다운 */}
-                                            <div>
-                                                <label className={labelClass}>음성 선택</label>
-                                                <div className="relative">
-                                                    <button
-                                                        type="button"
-                                                        aria-haspopup="listbox"
-                                                        aria-expanded={isVoiceDropdownOpen}
-                                                        onClick={() => setIsVoiceDropdownOpen(!isVoiceDropdownOpen)}
-                                                        className="w-full flex items-center justify-between px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-sm font-medium text-slate-700 outline-none transition-all hover:border-orange-400 focus:border-orange-500 focus:ring-4 focus:ring-orange-50"
-                                                    >
-                                                        <span>
-                                                            {TTS_VOICE_OPTIONS.find((opt) => opt.value === ttsVoiceId)?.label ?? ttsVoiceId}
-                                                        </span>
-                                                        <HiOutlineChevronDown className={`w-4 h-4 text-slate-400 transition-transform duration-200 ${isVoiceDropdownOpen ? 'rotate-180' : ''}`} />
-                                                    </button>
-                                                    <AnimatePresence>
-                                                        {isVoiceDropdownOpen && (
-                                                            <>
-                                                                <div className="fixed inset-0 z-40" onClick={() => setIsVoiceDropdownOpen(false)} />
-                                                                <motion.div
-                                                                    role="listbox"
-                                                                    initial={{ opacity: 0, y: -10 }}
-                                                                    animate={{ opacity: 1, y: 0 }}
-                                                                    exit={{ opacity: 0, y: -10 }}
-                                                                    transition={{ duration: 0.15 }}
-                                                                    className="absolute top-full left-0 mt-2 w-full bg-white/95 backdrop-blur-xl rounded-xl shadow-xl border border-slate-100 py-1.5 z-50 overflow-hidden"
-                                                                >
-                                                                    {TTS_VOICE_OPTIONS.map((opt) => (
-                                                                        <button
-                                                                            key={opt.value}
-                                                                            type="button"
-                                                                            role="option"
-                                                                            aria-selected={ttsVoiceId === opt.value}
-                                                                            onClick={() => {
-                                                                                setTtsVoiceId(opt.value);
-                                                                                setIsVoiceDropdownOpen(false);
-                                                                            }}
-                                                                            className={`w-full text-left px-4 py-2.5 text-sm font-medium transition-colors ${
-                                                                                ttsVoiceId === opt.value
-                                                                                    ? 'bg-orange-50 text-orange-600 font-bold'
-                                                                                    : 'text-slate-600 hover:bg-slate-50'
-                                                                            }`}
-                                                                        >
-                                                                            {opt.label}
-                                                                        </button>
-                                                                    ))}
-                                                                </motion.div>
-                                                            </>
-                                                        )}
-                                                    </AnimatePresence>
-                                                </div>
-                                            </div>
-
-                                            {/* 속도 & 피치 */}
-                                            <div className="grid grid-cols-2 gap-3">
-                                                <div>
-                                                    <label htmlFor="mascot-tts-speed" className={labelClass}>속도</label>
-                                                    <div className="space-y-2">
-                                                        <input
-                                                            id="mascot-tts-speed"
-                                                            type="range"
-                                                            min="0.5"
-                                                            max="2.0"
-                                                            step="0.1"
-                                                            value={ttsSpeed}
-                                                            onChange={(event) => setTtsSpeed(event.target.value)}
-                                                            className="w-full accent-orange-500"
-                                                        />
-                                                        <p className="text-center text-sm font-bold text-slate-600">{parseFloat(ttsSpeed).toFixed(1)}x</p>
-                                                    </div>
-                                                </div>
-
-                                                <div>
-                                                    <label htmlFor="mascot-tts-pitch" className={labelClass}>피치</label>
-                                                    <div className="space-y-2">
-                                                        <input
-                                                            id="mascot-tts-pitch"
-                                                            type="range"
-                                                            min="-10"
-                                                            max="10"
-                                                            step="1"
-                                                            value={ttsPitch}
-                                                            onChange={(event) => setTtsPitch(event.target.value)}
-                                                            className="w-full accent-orange-500"
-                                                        />
-                                                        <p className="text-center text-sm font-bold text-slate-600">{ttsPitch}</p>
-                                                    </div>
-                                                </div>
-                                            </div>
-
-                                            <p className="text-xs text-slate-400 px-1">
-                                                속도 1.0x, 피치 0이 기본값입니다. 변경하지 않으면 기본값이 적용됩니다.
-                                            </p>
-                                        </>
-                                    )}
                                 </div>
 
                                 {/* 액션 버튼 */}

--- a/src/features/mascot/presentation/components/MascotSettingsView.tsx
+++ b/src/features/mascot/presentation/components/MascotSettingsView.tsx
@@ -18,7 +18,7 @@ import { MascotModelCard } from './MascotModelCard';
 import { MascotFormModal } from './MascotFormModal';
 import type { CreateMascotRequest, UpdateMascotRequest } from '@/features/mascot/domain/entities/Mascot';
 
-type FormTab = 'basic' | 'prompt' | 'tts';
+type FormTab = 'basic' | 'prompt';
 
 /**
  * 마스코트 관리 메인 뷰
@@ -70,12 +70,6 @@ export function MascotSettingsView() {
     const handleClickEditPrompt = () => {
         setFormMode('edit');
         setFormInitialTab('prompt');
-        setIsFormOpen(true);
-    };
-
-    const handleClickEditTts = () => {
-        setFormMode('edit');
-        setFormInitialTab('tts');
         setIsFormOpen(true);
     };
 
@@ -244,7 +238,7 @@ export function MascotSettingsView() {
             >
                 <MascotInfoCard mascot={mascot} onEdit={handleClickEditInfo} />
                 <MascotPromptCard mascot={mascot} onEdit={handleClickEditPrompt} />
-                <MascotTtsCard mascot={mascot} onEdit={handleClickEditTts} />
+                <MascotTtsCard mascot={mascot} siteId={currentSiteId} onCloned={fetchMascot} />
                 <MascotModelCard
                     mascot={mascot}
                     generation={generation}

--- a/src/features/mascot/presentation/components/MascotSettingsView.tsx
+++ b/src/features/mascot/presentation/components/MascotSettingsView.tsx
@@ -282,7 +282,7 @@ function PageHeader({
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
     return (
-        <div className="flex items-start justify-between">
+        <div className="relative z-10 flex items-start justify-between">
             <div>
                 <h2 className="text-2xl font-bold text-slate-800 flex items-center gap-2">
                     <HiOutlineSparkles className="w-7 h-7 text-orange-500" />

--- a/src/features/mascot/presentation/components/MascotTtsCard.tsx
+++ b/src/features/mascot/presentation/components/MascotTtsCard.tsx
@@ -1,65 +1,152 @@
 'use client';
 
-import { HiOutlineSpeakerWave, HiOutlinePencilSquare } from 'react-icons/hi2';
-import type { Mascot } from '@/features/mascot/domain/entities/Mascot';
-import { TTS_VOICE_OPTIONS } from '@/features/mascot/domain/entities/Mascot';
+import { useState, useRef } from 'react';
+import {
+    HiOutlineMicrophone,
+    HiOutlineArrowUpTray,
+    HiOutlineCheckCircle,
+    HiOutlineXCircle,
+    HiOutlineSparkles,
+} from 'react-icons/hi2';
+import { useMascotVoiceClone } from '@/features/mascot/application/hooks/useMascotVoiceClone';
+import { VOICE_CLONE_ACCEPT_ATTRIBUTE } from '@/features/mascot/domain/entities/Mascot';
+import type { MascotTtsCardProps } from '@/features/mascot/presentation/types/MascotTtsCardProps';
 
-interface MascotTtsCardProps {
-    mascot: Mascot;
-    onEdit: () => void;
-}
+export function MascotTtsCard({ mascot, siteId, onCloned }: MascotTtsCardProps) {
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [selectedFile, setSelectedFile] = useState<File | null>(null);
+    const [voiceName, setVoiceName] = useState('');
 
-/**
- * TTS 음성 설정 카드
- */
-export function MascotTtsCard({ mascot, onEdit }: MascotTtsCardProps) {
-    const voiceLabel = TTS_VOICE_OPTIONS.find((option) => option.value === mascot.ttsVoiceId)?.label
-        ?? mascot.ttsVoiceId;
+    const { cloneVoice, isCloning, error, resetError } = useMascotVoiceClone(siteId);
+
+    const hasVoice = !!mascot.ttsVoiceId;
+    const isReadyToSubmit = selectedFile !== null && voiceName.trim().length > 0;
+
+    const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (!file) return;
+        resetError();
+        setSelectedFile(file);
+    };
+
+    const handleClone = async () => {
+        if (!selectedFile || isCloning) return;
+
+        const result = await cloneVoice(selectedFile, voiceName);
+        if (result) {
+            setSelectedFile(null);
+            setVoiceName('');
+            if (fileInputRef.current) fileInputRef.current.value = '';
+            await onCloned();
+        }
+    };
 
     return (
         <div className="bg-white rounded-2xl border border-slate-100 shadow-sm p-6">
             {/* 헤더 */}
-            <div className="flex items-center justify-between mb-5">
-                <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-xl bg-sky-50 flex items-center justify-center">
-                        <HiOutlineSpeakerWave className="w-5 h-5 text-sky-500" />
-                    </div>
-                    <div>
-                        <h3 className="text-sm font-bold text-slate-800">TTS 음성</h3>
-                        <p className="text-xs text-slate-400">텍스트 음성 변환 설정</p>
-                    </div>
+            <div className="flex items-center gap-3 mb-5">
+                <div className="w-10 h-10 rounded-xl bg-purple-50 flex items-center justify-center">
+                    <HiOutlineMicrophone className="w-5 h-5 text-purple-500" />
                 </div>
-                <button
-                    onClick={onEdit}
-                    className="flex items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-orange-600 transition-all duration-200 px-3 py-1.5 rounded-lg hover:bg-orange-50"
-                >
-                    <HiOutlinePencilSquare className="w-4 h-4" />
-                    수정
-                </button>
+                <div>
+                    <h3 className="text-sm font-bold text-slate-800">TTS 음성</h3>
+                    <p className="text-xs text-slate-400">Cartesia 음성 클로닝</p>
+                </div>
             </div>
 
-            {/* 음성 정보 */}
+            {/* 현재 음성 적용 상태 */}
+            {hasVoice && (
+                <div className="bg-green-50 rounded-xl p-4 mb-4 flex items-center gap-3">
+                    <HiOutlineCheckCircle className="w-5 h-5 text-green-500 shrink-0" />
+                    <div className="min-w-0">
+                        <p className="text-sm font-medium text-green-700">음성 적용 중</p>
+                        <p className="text-xs text-green-600 truncate font-mono">{mascot.ttsVoiceId}</p>
+                    </div>
+                </div>
+            )}
+
+            {/* 에러 */}
+            {error && (
+                <div className="bg-red-50 rounded-xl p-4 mb-4 flex items-start gap-3">
+                    <HiOutlineXCircle className="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
+                    <div className="min-w-0">
+                        <p className="text-sm font-medium text-red-700">클로닝 실패</p>
+                        <p className="text-xs text-red-600 mt-0.5">{error.message}</p>
+                    </div>
+                </div>
+            )}
+
+            {/* 클로닝 진행 중 안내 */}
+            {isCloning && (
+                <div className="bg-orange-50 rounded-xl p-4 mb-4 flex items-center gap-3">
+                    <div className="w-4 h-4 border-[2.5px] border-orange-500 border-t-transparent rounded-full animate-spin shrink-0" />
+                    <p className="text-sm font-medium text-orange-700">
+                        Cartesia에서 음성을 생성 중입니다... (수십 초 소요)
+                    </p>
+                </div>
+            )}
+
             <div className="space-y-3">
-                <div className="bg-slate-50 rounded-xl px-4 py-3">
-                    <p className="text-xs text-slate-400 mb-0.5">음성</p>
-                    <p className="text-sm font-medium text-slate-700">{voiceLabel}</p>
+                <p className="text-xs font-bold text-slate-400">
+                    {hasVoice ? '새 음성으로 교체' : '음성 샘플로 클로닝'}
+                </p>
+
+                {/* 보이스 이름 입력 */}
+                <input
+                    type="text"
+                    value={voiceName}
+                    onChange={(event) => setVoiceName(event.target.value)}
+                    placeholder="보이스 이름 (예: 해치 목소리)"
+                    disabled={isCloning}
+                    aria-label="보이스 이름"
+                    className="w-full px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-sm font-medium text-slate-700 placeholder:text-slate-400 outline-none transition-all hover:border-orange-400 focus:border-orange-500 focus:ring-4 focus:ring-orange-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                />
+
+                {/* 파일 업로드 박스 */}
+                <div
+                    onClick={() => !isCloning && fileInputRef.current?.click()}
+                    className={`relative border-2 border-dashed rounded-xl overflow-hidden transition-all duration-200 ${
+                        isCloning
+                            ? 'border-slate-200 bg-slate-50 cursor-not-allowed'
+                            : 'border-slate-200 hover:border-orange-400 cursor-pointer hover:bg-orange-50/30'
+                    }`}
+                >
+                    {selectedFile ? (
+                        <div className="py-6 flex flex-col items-center gap-1.5">
+                            <HiOutlineMicrophone className="w-6 h-6 text-orange-400" />
+                            <p className="text-sm font-medium text-slate-700">{selectedFile.name}</p>
+                            <p className="text-xs text-slate-400">
+                                {(selectedFile.size / 1024).toFixed(0)}KB
+                            </p>
+                        </div>
+                    ) : (
+                        <div className="py-10 flex flex-col items-center gap-2">
+                            <HiOutlineArrowUpTray className="w-8 h-8 text-slate-300" />
+                            <p className="text-sm text-slate-500">WAV, MP3, M4A, OGG, WEBM</p>
+                            <p className="text-xs text-slate-400">클릭하여 음성 파일 선택 (최대 800KB)</p>
+                        </div>
+                    )}
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept={VOICE_CLONE_ACCEPT_ATTRIBUTE}
+                        onChange={handleFileSelect}
+                        disabled={isCloning}
+                        className="hidden"
+                        aria-label="음성 파일 선택"
+                    />
                 </div>
 
-                {mascot.ttsVoiceJson && (
-                    <div className="grid grid-cols-2 gap-3">
-                        {mascot.ttsVoiceJson.speed !== undefined && (
-                            <div className="bg-slate-50 rounded-xl px-4 py-3">
-                                <p className="text-xs text-slate-400 mb-0.5">속도</p>
-                                <p className="text-sm font-medium text-slate-700">{mascot.ttsVoiceJson.speed}x</p>
-                            </div>
-                        )}
-                        {mascot.ttsVoiceJson.pitch !== undefined && (
-                            <div className="bg-slate-50 rounded-xl px-4 py-3">
-                                <p className="text-xs text-slate-400 mb-0.5">피치</p>
-                                <p className="text-sm font-medium text-slate-700">{mascot.ttsVoiceJson.pitch}</p>
-                            </div>
-                        )}
-                    </div>
+                {/* 클로닝 버튼 */}
+                {isReadyToSubmit && !isCloning && (
+                    <button
+                        onClick={handleClone}
+                        aria-label="음성 클로닝 시작"
+                        className="w-full flex items-center justify-center gap-2 bg-orange-500 hover:bg-orange-600 text-white font-bold text-sm rounded-xl px-5 py-3 shadow-lg shadow-orange-200 transition-all duration-200 active:scale-[0.98]"
+                    >
+                        <HiOutlineSparkles className="w-4 h-4" />
+                        음성 클로닝 시작
+                    </button>
                 )}
             </div>
         </div>

--- a/src/features/mascot/presentation/types/MascotTtsCardProps.ts
+++ b/src/features/mascot/presentation/types/MascotTtsCardProps.ts
@@ -1,0 +1,7 @@
+import type { Mascot } from '@/features/mascot/domain/entities/Mascot';
+
+export interface MascotTtsCardProps {
+    mascot: Mascot;
+    siteId: number;
+    onCloned: () => Promise<void> | void;
+}

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -43,6 +43,7 @@ export type ErrorCode =
     | 'DOMAIN_RULE_VIOLATION'       // 422 도메인 규칙 위반
     | 'RATE_LIMITED'                // 429 과다 요청
     | 'DOC_UPLOAD_FAILED'           // 500 파일 업로드 실패
+    | 'VOICE_CLONE_FAILED'          // 500 음성 클로닝 실패
     | 'INTERNAL_ERROR'              // 500 서버 오류
     | 'UPSTREAM_TIMEOUT'            // 503 외부 의존 장애
     | 'FEIGN_ERROR';                // 500 Core/FastAPI 타임아웃


### PR DESCRIPTION
# 🔀 PR 요약
- resolves #이슈번호

## ✨ 변경 내용
- 마스코트 TTS 카드를 Cartesia 음성 클로닝 UI로 교체 (Wavenet 드롭다운·speed/pitch제거)
- `POST /admin/sites/{siteId}/mascot/voice/clone` 연동 (multipart/form-data)
- MascotFormModal TTS 탭 제거
- 마스코트 페이지 관광지 드롭다운 z-index 수정 (카드에 가려지던 문제)
- 음성 클로닝 API 타임아웃 60초로 설정

## 🖼️ 스크린샷 (UI 변경 시 필수)
<img src="" width="50%" />

## 🔍 주요 포인트
- 클라이언트 사전 검증: 확장자(.wav/.mp3/.m4a/.m4r/.ogg/.webm), 800KB 제한, 보이스 이름 필수
- 재진입 방지 ref + 에러코드별 한글 메시지 분기 (400/404/500/503)

## 🧪 테스트
- [X] 로컬에서 빌드 및 실행 확인
- [X] 주요 기능 동작 확인 (크롬 개발자 도구)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 마스코트 음성 클로닝 기능 추가: 음성 파일을 업로드하여 마스코트의 맞춤 음성 설정이 가능합니다.

* **Changes**
  * 기존 TTS 음성 드롭다운 및 속도·피치 조정 기능이 제거되었습니다.
  * 음성 설정이 클로닝 기반의 새로운 방식으로 변경되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-Guideon/guideon-frontend/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->