### PR TITLE
feat: 마스코트 기본 정보만으로 생성 가능하도록 ttsVoiceId·modelId 임시값 처리

### DIFF
--- a/src/features/mascot/domain/entities/Mascot.ts
+++ b/src/features/mascot/domain/entities/Mascot.ts
@@ -132,3 +132,15 @@ export const VOICE_CLONE_ACCEPTED_EXTENSIONS = [
 export const VOICE_CLONE_ACCEPT_ATTRIBUTE = VOICE_CLONE_ACCEPTED_EXTENSIONS.join(',');
 export const VOICE_CLONE_MAX_BYTES = 800 * 1024;
 export const VOICE_CLONE_DEFAULT_LANGUAGE = 'ko';
+
+/**
+ * 마스코트 최초 생성 시 ttsVoiceId 자리에 사용하는 임시 기본값.
+ * TTS 카드에서 음성 클로닝 완료 후 PATCH 로 실제 값으로 교체됩니다.
+ */
+export const PENDING_VOICE_ID = 'PENDING' as const;
+
+/**
+ * 마스코트 최초 생성 시 modelId 자리에 사용하는 임시 기본값.
+ * 3D 모델 생성 완료 후 PATCH 로 실제 값으로 교체됩니다.
+ */
+export const PENDING_MODEL_ID = 'NONE' as const;

--- a/src/features/mascot/presentation/components/MascotFormModal.tsx
+++ b/src/features/mascot/presentation/components/MascotFormModal.tsx
@@ -13,7 +13,7 @@ import type {
     CreateMascotRequest,
     UpdateMascotRequest,
 } from '@/features/mascot/domain/entities/Mascot';
-import { DEFAULT_ANIM_OPTIONS } from '@/features/mascot/domain/entities/Mascot';
+import { DEFAULT_ANIM_OPTIONS, PENDING_MODEL_ID, PENDING_VOICE_ID } from '@/features/mascot/domain/entities/Mascot';
 
 type FormTab = 'basic' | 'prompt';
 
@@ -52,7 +52,6 @@ export function MascotFormModal({
 
     // 기본 정보
     const [name, setName] = useState('');
-    const [modelId, setModelId] = useState('');
     const [defaultAnim, setDefaultAnim] = useState('IDLE_A');
     const [greetingMsg, setGreetingMsg] = useState('');
     const [isActive, setIsActive] = useState(true);
@@ -73,7 +72,6 @@ export function MascotFormModal({
 
         if (mode === 'edit' && editTarget) {
             setName(editTarget.name);
-            setModelId(editTarget.modelId);
             setDefaultAnim(editTarget.defaultAnim);
             setGreetingMsg(editTarget.greetingMsg);
             setIsActive(editTarget.isActive);
@@ -83,7 +81,6 @@ export function MascotFormModal({
             setAnswerStyle(editTarget.promptConfig?.answer_style ?? '');
         } else {
             setName('');
-            setModelId('');
             setDefaultAnim('IDLE_A');
             setGreetingMsg('');
             setIsActive(true);
@@ -116,19 +113,21 @@ export function MascotFormModal({
         event.preventDefault();
 
         if (mode === 'create') {
+            // ttsVoiceId, modelId는 생성 직후 각 카드에서 PATCH로 실제값을 덮어씁니다.
+            // 백엔드 필수값 충족을 위해 임시 기본값을 전송합니다.
             const request: CreateMascotRequest = {
                 name: name.trim(),
-                modelId: modelId.trim(),
+                modelId: PENDING_MODEL_ID,
                 defaultAnim,
                 greetingMsg: greetingMsg.trim(),
                 systemPrompt: systemPrompt.trim(),
                 promptConfig: buildPromptConfig(),
+                ttsVoiceId: PENDING_VOICE_ID,
             };
             onSubmit(request);
         } else {
             const request: UpdateMascotRequest = {
                 name: name.trim(),
-                modelId: modelId.trim(),
                 defaultAnim,
                 greetingMsg: greetingMsg.trim(),
                 systemPrompt: systemPrompt.trim(),
@@ -141,7 +140,6 @@ export function MascotFormModal({
 
     const isFormValid =
         name.trim().length > 0 &&
-        modelId.trim().length > 0 &&
         greetingMsg.trim().length > 0 &&
         systemPrompt.trim().length > 0;
 
@@ -234,18 +232,7 @@ export function MascotFormModal({
                                                 />
                                             </div>
 
-                                            <div>
-                                                <label htmlFor="mascot-model-id" className={labelClass}>모델 ID *</label>
-                                                <input
-                                                    id="mascot-model-id"
-                                                    type="text"
-                                                    value={modelId}
-                                                    onChange={(event) => setModelId(event.target.value)}
-                                                    placeholder="예: haechi_v1"
-                                                    maxLength={100}
-                                                    className={inputClass}
-                                                />
-                                            </div>
+                                            {/* 모델 ID는 3D 모델 생성 카드에서 별도 설정합니다 */}
 
                                             {/* 기본 애니메이션 드롭다운 */}
                                             <div>

--- a/src/features/mascot/presentation/components/MascotInfoCard.tsx
+++ b/src/features/mascot/presentation/components/MascotInfoCard.tsx
@@ -2,6 +2,7 @@
 
 import { HiOutlineSparkles, HiOutlineChatBubbleLeftRight, HiOutlinePencilSquare } from 'react-icons/hi2';
 import type { Mascot } from '@/features/mascot/domain/entities/Mascot';
+import { PENDING_MODEL_ID } from '@/features/mascot/domain/entities/Mascot';
 
 interface MascotInfoCardProps {
     mascot: Mascot;
@@ -67,7 +68,13 @@ export function MascotInfoCard({ mascot, onEdit }: MascotInfoCardProps) {
                 <div className="grid grid-cols-2 gap-3">
                     <div className="bg-slate-50 rounded-xl px-4 py-3">
                         <p className="text-xs text-slate-400 mb-0.5">모델 ID</p>
-                        <p className="text-sm font-medium text-slate-700 truncate">{mascot.modelId}</p>
+                        <p className={`text-sm font-medium truncate ${
+                            mascot.modelId === PENDING_MODEL_ID
+                                ? 'text-slate-400 italic'
+                                : 'text-slate-700'
+                        }`}>
+                            {mascot.modelId === PENDING_MODEL_ID ? '미설정' : mascot.modelId}
+                        </p>
                     </div>
                     <div className="bg-slate-50 rounded-xl px-4 py-3">
                         <p className="text-xs text-slate-400 mb-0.5">기본 애니메이션</p>

--- a/src/features/mascot/presentation/components/MascotTtsCard.tsx
+++ b/src/features/mascot/presentation/components/MascotTtsCard.tsx
@@ -9,7 +9,7 @@ import {
     HiOutlineSparkles,
 } from 'react-icons/hi2';
 import { useMascotVoiceClone } from '@/features/mascot/application/hooks/useMascotVoiceClone';
-import { VOICE_CLONE_ACCEPT_ATTRIBUTE } from '@/features/mascot/domain/entities/Mascot';
+import { VOICE_CLONE_ACCEPT_ATTRIBUTE, PENDING_VOICE_ID } from '@/features/mascot/domain/entities/Mascot';
 import type { MascotTtsCardProps } from '@/features/mascot/presentation/types/MascotTtsCardProps';
 
 export function MascotTtsCard({ mascot, siteId, onCloned }: MascotTtsCardProps) {
@@ -19,7 +19,7 @@ export function MascotTtsCard({ mascot, siteId, onCloned }: MascotTtsCardProps) 
 
     const { cloneVoice, isCloning, error, resetError } = useMascotVoiceClone(siteId);
 
-    const hasVoice = !!mascot.ttsVoiceId;
+    const hasVoice = !!mascot.ttsVoiceId && mascot.ttsVoiceId !== PENDING_VOICE_ID;
     const isReadyToSubmit = selectedFile !== null && voiceName.trim().length > 0;
 
     const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## ✨ 변경 내용
- 마스코트 생성 시 ttsVoiceId, modelId가 없으면 생성이 불가능한 문제를 해결합니다.
- 기본 정보(이름, 인사말, 시스템 프롬프트)만 입력하면 마스코트를 즉시 생성할 수 있도록 POST 시 임시 기본값(PENDING / NONE)을 자동 주입하고, 이후 각 카드에서 PATCH로 실제값을 덮어씁니다.

## 🖼️ 스크린샷 (UI 변경 시 필수)
<img src="" width="50%" />

## 🔍 주요 포인트
- 

## 🧪 테스트
- [x] 로컬에서 빌드 및 실행 확인
- [x] 주요 기능 동작 확인 (크롬 개발자 도구)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마스코트 생성 과정에서 모델 ID 입력 요구사항 제거
  * 임시 처리 상태를 UI에서 더 명확하게 표시 (예: 모델 ID 미설정 상태 구분)
  * 음성 클로닝 대기 상태 중 불필요한 UI 요소 숨김

<!-- end of auto-generated comment: release notes by coderabbit.ai -->